### PR TITLE
chore: Update track.related-pois.directive.ts oc: 3803

### DIFF
--- a/src/directives/track.related-pois.directive.ts
+++ b/src/directives/track.related-pois.directive.ts
@@ -134,6 +134,10 @@ export class WmMapTrackRelatedPoisDirective
    * The input property for the radius of the alert POI in the track.
    */
   @Input() wmMapTrackRelatedPoisAlertPoiRadius: number;
+
+  @Input() set wmMapReletedPoisDisableClusterLayer(disabled: boolean) {
+    this._poisLayer?.setVisible(!disabled);
+  }
   /**
    * @description
    * The output event for POI click.


### PR DESCRIPTION
- Added new input property `wmMapReletedPoisDisableClusterLayer` to disable the cluster layer for related POIs
- Updated the logic to toggle visibility of the POI layer based on the value of `disabled`
