### PR TITLE
chore: Remove unnecessary condition in fitViewFromLonLat oc: 4143

### DIFF
--- a/src/directives/layer.directive.ts
+++ b/src/directives/layer.directive.ts
@@ -90,8 +90,7 @@ export class WmMapLayerDirective extends WmMapBaseDirective implements OnChanges
     const hostname: string = window.location.href;
     if (
       l != null &&
-      l.bbox != null &&
-      (hostname.indexOf('track=-1') >= 0 || hostname.indexOf('track=') >= 0)
+      l.bbox != null
     ) {
       this.fitViewFromLonLat(l.bbox);
     }


### PR DESCRIPTION
The commit removes an unnecessary condition in the fitViewFromLonLat method of the WmMapLayerDirective class. The condition checked for specific values in the hostname, but it is no longer needed.
