### PR TITLE
chore(geojson.directive): Add support for single Feature in trackgeojson oc: 4247

### DIFF
--- a/src/directives/geojson.directive.ts
+++ b/src/directives/geojson.directive.ts
@@ -94,6 +94,8 @@ export class WmMapGeojsonDirective extends WmMapBaseDirective {
     const features = [];
     if (trackgeojson.type === 'FeatureCollection') {
       return trackgeojson;
+    } else if (trackgeojson.type === 'Feature') {
+      features.push(trackgeojson);
     } else if (trackgeojson?.geoJson) {
       features.push(trackgeojson.geoJson);
     } else if (trackgeojson?.geometry) {


### PR DESCRIPTION
This commit adds support for handling a single Feature object in the trackgeojson input. If the type of trackgeojson is 'Feature', it will be added to the features array. This allows more flexibility in working with different types of GeoJSON data.
