### PR TITLE
chore(directives): add logic to update POIs layer oc:4454

### DIFF
--- a/src/directives/ugc-pois.directive.ts
+++ b/src/directives/ugc-pois.directive.ts
@@ -101,6 +101,14 @@ export class WmUgcPoisDirective extends WmMapBaseDirective implements OnChanges 
         if (changes.wmMapUgcUnselectedPoi != null) {
           clearLayer(this._selectedUgcPoiLayer);
         }
+        if (
+          changes.wmMapUgcPois &&
+          changes.wmMapUgcPois.previousValue != null &&
+          changes.wmMapUgcPois.currentValue != null &&
+          changes.wmMapUgcPois.previousValue.length != changes.wmMapUgcPois.currentValue.length
+        ) {
+          this._addPoisLayer(changes.wmMapUgcPois.currentValue);
+        }
       });
   }
 


### PR DESCRIPTION
This commit adds logic to the `WmUgcPoisDirective` class in the `ugc-pois.directive.ts` file. The logic checks for changes in the `wmMapUgcPois` property and updates the POIs layer accordingly.
