### PR TITLE
chore(map): enable pinch rotation on map component oc: 4773

### DIFF
--- a/src/components/map/map.component.ts
+++ b/src/components/map/map.component.ts
@@ -302,7 +302,7 @@ export class WmMapComponent implements OnChanges, AfterViewInit, OnDestroy {
       doubleClickZoom: false,
       dragPan: true,
       mouseWheelZoom: true,
-      pinchRotate: false,
+      pinchRotate: true,
       altShiftDragRotate: false,
     });
   }
@@ -444,7 +444,6 @@ export class WmMapComponent implements OnChanges, AfterViewInit, OnDestroy {
       this.wmMapRotateEVT$.emit(degree);
     }
     this.mapDegrees = degree;
-    this.map.updateSize();
   }
 
   /**


### PR DESCRIPTION
This commit enables the pinchRotate option in the map configuration, allowing users to rotate the map by pinching on touch devices. The previous value was set to false, but it has been changed to true to enable this feature.
