### PR TITLE
chore: Fix typo in track.related-pois.directive.ts oc:5443

### DIFF
--- a/src/directives/track.related-pois.directive.ts
+++ b/src/directives/track.related-pois.directive.ts
@@ -477,7 +477,7 @@ export class WmMapTrackRelatedPoisDirective
     }
     const svgIcon = properties?.taxonomy?.poi_type?.icon ?? null;
     const poiFromPois = this._wmMapPoisPois?.value?.getFeatureById(properties.id) ?? null;
-    if (properties?.feature_image?.sizes['108x137'] != null) {
+    if (properties?.feature_image?.sizes?.['108x137'] != null) {
       const {marker} = await this._createPoiCanvasIcon(poi, null, selected);
       return marker;
     } else if (poiFromPois != null) {


### PR DESCRIPTION
The code change fixes a typo in the track.related-pois.directive.ts file. The condition for checking the feature image size has been corrected to access the '108x137' property correctly.
