### PR TITLE
🐛 fix(directives): handle reloadCustomTracks input more robustly oc:5581

### DIFF
--- a/src/directives/custom-tracks.draw.directive.ts
+++ b/src/directives/custom-tracks.draw.directive.ts
@@ -100,8 +100,10 @@ export class wmMapCustomTrackDrawTrackDirective extends WmMapBaseDirective {
     }
   }
 
-  @Input() set reloadCustomTracks(val) {
-    if (val != null) this._clear();
+  @Input() set reloadCustomTracks(val: boolean) {
+    if (val && this._customTrackLayer?.getSource()) {
+      this._clear();
+    }
   }
 
   @Input() customTracks: any[];


### PR DESCRIPTION
- add type checking for reloadCustomTracks input parameter
- ensure custom track layer source exists before clearing
