### PR TITLE
chore(map): ✨ add 'e2e-map-ready' attribute to body on render complete oc:5624

### DIFF
--- a/src/components/map/map.component.ts
+++ b/src/components/map/map.component.ts
@@ -373,6 +373,9 @@ export class WmMapComponent implements OnChanges, AfterViewInit, OnDestroy {
       target: this.mapContainer.nativeElement,
     });
 
+    this.map.once('rendercomplete', () => {
+      document.body.setAttribute('e2e-map-ready', 'true');
+    });
     this.map.on('postrender', () => {
       this._updateDegrees();
     });


### PR DESCRIPTION
This update introduces a new feature where an 'e2e-map-ready' attribute is set on the document body once the map's render is complete. This enhancement is useful for end-to-end testing, ensuring that tests only proceed when the map is fully rendered.
