### PR TITLE
refactor(directives): ♻️ extract popover logic to a base directive oc:5569

### DIFF
--- a/src/directives/custom-tracks.draw.directive.ts
+++ b/src/directives/custom-tracks.draw.directive.ts
@@ -1,5 +1,4 @@
 import {
-  ComponentRef,
   Directive,
   ElementRef,
   EventEmitter,
@@ -28,18 +27,18 @@ import VectorSource from 'ol/source/Vector';
 import {filter, take} from 'rxjs/operators';
 import {createIconFeatureFromSrc} from '../../src/utils/ol';
 import {getLineStyle} from '../../src/utils/styles';
-import {WmMapComponent, WmMapPopover} from '../components';
-import {WmMapBaseDirective} from './base.directive';
+import {WmMapComponent} from '../components';
 import {stopPropagation} from 'ol/events/Event';
 import {WmFeature} from '@wm-types/feature';
 import {LineString} from 'geojson';
 import {WmSlopeChartHoverElements} from '@wm-types/slope-chart';
+import {WmMapPopoverBaseDirective} from './popover-base.directive';
 export const RECORD_TRACK_ID: string = 'wm-current_record_track';
 
 @Directive({
   selector: '[wmMapCustomTrackDrawTrack]',
 })
-export class wmMapCustomTrackDrawTrackDirective extends WmMapBaseDirective {
+export class wmMapCustomTrackDrawTrackDirective extends WmMapPopoverBaseDirective {
   /**
    * @description
    * A private instance variable that represents a vector layer for custom points of interest (POI) on the map.
@@ -85,18 +84,15 @@ export class wmMapCustomTrackDrawTrackDirective extends WmMapBaseDirective {
    * An array of `Coordinate` objects that define a path or shape on the map.
    */
   private _points: Coordinate[] = [];
-  private _popoverMsg: string = 'Clicca sulla mappa per avviare la creazione di un percorso';
-  private _popoverRef: ComponentRef<WmMapPopover> = null;
+  protected _popoverMsg: string = 'Clicca sulla mappa per avviare la creazione di un percorso';
 
   @Input('wmMapCustomTrackDrawTrack') set enabled(val: boolean) {
     this._enabled$.next(val);
     this._customTrackLayer?.setVisible(val);
-    if (this._popoverRef != null && this._popoverRef.instance != null) {
-      if (val) {
-        this._popoverRef.instance.message$.next(this.translationCallback(this._popoverMsg));
-      } else {
-        this._popoverRef.instance.message$.next(null);
-      }
+    if (val) {
+      this._updatePopoverMessage(this.translationCallback(this._popoverMsg));
+    } else {
+      this._updatePopoverMessage(null);
     }
   }
 
@@ -125,11 +121,11 @@ export class wmMapCustomTrackDrawTrackDirective extends WmMapBaseDirective {
    */
   constructor(
     private _toastCtrl: ToastController,
-    private _viewContainerRef: ViewContainerRef,
-    private _element: ElementRef,
+    protected _viewContainerRef: ViewContainerRef,
+    protected _element: ElementRef,
     @Host() mapCmp: WmMapComponent,
   ) {
-    super(mapCmp);
+    super(mapCmp, _viewContainerRef, _element);
     this.mapCmp.isInit$
       .pipe(
         filter(f => f === true),
@@ -181,13 +177,6 @@ export class wmMapCustomTrackDrawTrackDirective extends WmMapBaseDirective {
     this.mapCmp.map.on('click', (evt: MapBrowserEvent<UIEvent>) => {
       this.onClick(evt);
     });
-  }
-
-  _initPopover(): void {
-    this._popoverRef = this._viewContainerRef.createComponent(WmMapPopover);
-    this._popoverRef.setInput('cssClass', 'draw-path-alert');
-    const host = this._element.nativeElement;
-    host.insertBefore(this._popoverRef.location.nativeElement, host.firstChild);
   }
 
   onClick(evt: MapBrowserEvent<UIEvent>): void {
@@ -282,8 +271,7 @@ export class wmMapCustomTrackDrawTrackDirective extends WmMapBaseDirective {
     this._customTrackLayer.getSource().clear();
     this._customPoiLayer.getSource().clear();
     this._points = [];
-
-    this._popoverRef?.instance?.message$.next(this.translationCallback(this._popoverMsg));
+    this._updatePopoverMessage(this.translationCallback(this._popoverMsg));
   }
 
   /**

--- a/src/directives/draw-ugc-poi.directive.ts
+++ b/src/directives/draw-ugc-poi.directive.ts
@@ -1,5 +1,12 @@
-import {Directive, EventEmitter, Host, Input, Output, SimpleChanges} from '@angular/core';
-import {WmMapBaseDirective} from './base.directive';
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Host,
+  Input,
+  Output,
+  ViewContainerRef,
+} from '@angular/core';
 import {WmMapComponent} from '../components';
 import {WmFeature} from '@wm-types/feature';
 import {Point} from 'geojson';
@@ -13,14 +20,16 @@ import {fromLonLat, toLonLat} from 'ol/proj';
 import {Point as OlPoint} from 'ol/geom';
 import {Feature, MapBrowserEvent} from 'ol';
 import {Icon, Style} from 'ol/style';
+import {WmMapPopoverBaseDirective} from './popover-base.directive';
 
 @Directive({
   selector: '[wmMapDrawUgcPoi]',
 })
-export class WmMapDrawUgcPoiDirective extends WmMapBaseDirective {
+export class WmMapDrawUgcPoiDirective extends WmMapPopoverBaseDirective {
   private _ugcPoidrawn: WmFeature<Point>;
   private _drawUgcPoiLayer: VectorLayer<VectorSource>;
   private _enabled$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  protected _popoverMsg: string = 'Clicca sulla mappa per avviare la creazione di un POI';
 
   @Output() wmMapDrawUgcPoiEvt: EventEmitter<WmFeature<Point>> = new EventEmitter<
     WmFeature<Point>
@@ -28,8 +37,10 @@ export class WmMapDrawUgcPoiDirective extends WmMapBaseDirective {
 
   @Input() set wmMapDrawUgcPoiPoi(ugcPoi: WmFeature<Point> | null) {
     this._ugcPoidrawn = ugcPoi;
+    this._updatePopoverMessage(null);
     this._drawUgcPoiIcon(this._ugcPoidrawn);
   }
+
   @Input('wmMapDrawUgcPoiEnabled') set enabled(val: boolean) {
     this._enabled$.next(val);
     this._drawUgcPoiLayer?.setVisible(val);
@@ -43,10 +54,20 @@ export class WmMapDrawUgcPoiDirective extends WmMapBaseDirective {
         console.error(e);
       }
     }
+
+    if (val) {
+      this._updatePopoverMessage(this._popoverMsg);
+    } else {
+      this._updatePopoverMessage(null);
+    }
   }
 
-  constructor(@Host() mapCmp: WmMapComponent) {
-    super(mapCmp);
+  constructor(
+    @Host() mapCmp: WmMapComponent,
+    protected _viewContainerRef: ViewContainerRef,
+    protected _element: ElementRef,
+  ) {
+    super(mapCmp, _viewContainerRef, _element);
     this.mapCmp.isInit$
       .pipe(
         filter(f => f === true),
@@ -60,21 +81,32 @@ export class WmMapDrawUgcPoiDirective extends WmMapBaseDirective {
   private _init(): void {
     this._drawUgcPoiLayer = createLayer(this._drawUgcPoiLayer, UGC_POI_DRAWN_ZINDEX);
     this.mapCmp.map.addLayer(this._drawUgcPoiLayer);
+    this._initPopover();
   }
 
   private _onClick = (evt: MapBrowserEvent<UIEvent>): void => {
     const coordinates = toLonLat(evt.coordinate);
-    if (this._ugcPoidrawn?.geometry?.coordinates != null) {
-      const newPoi = {
+    let newPoi: WmFeature<Point>;
+    if (!this._ugcPoidrawn) {
+      newPoi = {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: coordinates,
+        },
+        properties: {},
+      };
+    } else {
+      newPoi = {
         ...this._ugcPoidrawn,
         geometry: {
           ...this._ugcPoidrawn.geometry,
           coordinates: coordinates,
         },
       };
-      this._drawUgcPoiIcon(newPoi);
-      this.wmMapDrawUgcPoiEvt.emit(newPoi);
     }
+    this._drawUgcPoiIcon(newPoi);
+    this.wmMapDrawUgcPoiEvt.emit(newPoi);
   };
 
   private _drawUgcPoiIcon(ugcPoi: WmFeature<Point>): void {

--- a/src/directives/popover-base.directive.ts
+++ b/src/directives/popover-base.directive.ts
@@ -1,0 +1,31 @@
+import {ComponentRef, Directive, ElementRef, Host, ViewContainerRef} from '@angular/core';
+import {WmMapPopover} from '../components';
+import {WmMapBaseDirective} from './base.directive';
+import {WmMapComponent} from '../components';
+
+@Directive()
+export abstract class WmMapPopoverBaseDirective extends WmMapBaseDirective {
+  protected _popoverRef: ComponentRef<WmMapPopover> = null;
+  protected _popoverMsg: string;
+
+  constructor(
+    @Host() mapCmp: WmMapComponent,
+    protected _viewContainerRef: ViewContainerRef,
+    protected _element: ElementRef,
+  ) {
+    super(mapCmp);
+  }
+
+  protected _initPopover(): void {
+    this._popoverRef = this._viewContainerRef.createComponent(WmMapPopover);
+    this._popoverRef.setInput('cssClass', 'draw-path-alert');
+    const host = this._element.nativeElement;
+    host.insertBefore(this._popoverRef.location.nativeElement, host.firstChild);
+  }
+
+  protected _updatePopoverMessage(message: string | null): void {
+    if (this._popoverRef?.instance) {
+      this._popoverRef.instance.message$.next(message);
+    }
+  }
+}


### PR DESCRIPTION
This commit refactors the popover logic by extracting it into a new base directive, `WmMapPopoverBaseDirective`. This change promotes code reuse and simplifies the `wmMapCustomTrackDrawTrackDirective` and `WmMapDrawUgcPoiDirective` by moving shared popover-related functionality to the new base directive. The `_initPopover` and `_updatePopoverMessage` methods are now part of `WmMapPopoverBaseDirective`, reducing duplication and improving maintainability across directives that need popover functionality.

Changes include:
- Creating `WmMapPopoverBaseDirective` to handle popover initialization and message updates.
- Updating `wmMapCustomTrackDrawTrackDirective` and `WmMapDrawUgcPoiDirective` to extend `WmMapPopoverBaseDirective` instead of `WmMapBaseDirective`.
- Removing redundant popover-related code from the aforementioned directives.
- Adjusting constructors to pass necessary parameters to the base class.
