### PR TITLE
refactor(directives): ♻️ update popover message handling logic oc:5569

### DIFF
--- a/src/directives/custom-tracks.draw.directive.ts
+++ b/src/directives/custom-tracks.draw.directive.ts
@@ -181,7 +181,7 @@ export class wmMapCustomTrackDrawTrackDirective extends WmMapPopoverBaseDirectiv
 
   onClick(evt: MapBrowserEvent<UIEvent>): void {
     if (this._enabled$.value) {
-      this._popoverRef.instance.message$.next(null);
+      this._updatePopoverMessage(null);
       let featuresAvailableInClick = null;
       try {
         featuresAvailableInClick = this.mapCmp.map.getFeaturesAtPixel(evt.pixel, {
@@ -271,7 +271,12 @@ export class wmMapCustomTrackDrawTrackDirective extends WmMapPopoverBaseDirectiv
     this._customTrackLayer.getSource().clear();
     this._customPoiLayer.getSource().clear();
     this._points = [];
-    this._updatePopoverMessage(this.translationCallback(this._popoverMsg));
+    const countFeatures = this._customTrackLayer?.getSource()?.getFeatures()?.length;
+    if (countFeatures === 0 && this._enabled$.value) {
+      this._updatePopoverMessage(this.translationCallback(this._popoverMsg));
+    } else {
+      this._updatePopoverMessage(null);
+    }
   }
 
   /**

--- a/src/directives/draw-ugc-poi.directive.ts
+++ b/src/directives/draw-ugc-poi.directive.ts
@@ -37,8 +37,12 @@ export class WmMapDrawUgcPoiDirective extends WmMapPopoverBaseDirective {
 
   @Input() set wmMapDrawUgcPoiPoi(ugcPoi: WmFeature<Point> | null) {
     this._ugcPoidrawn = ugcPoi;
-    this._updatePopoverMessage(null);
     this._drawUgcPoiIcon(this._ugcPoidrawn);
+    if (ugcPoi == null && this._enabled$.value) {
+      this._updatePopoverMessage(this._popoverMsg);
+    } else {
+      this._updatePopoverMessage(null);
+    }
   }
 
   @Input('wmMapDrawUgcPoiEnabled') set enabled(val: boolean) {


### PR DESCRIPTION
Modified the logic for updating popover messages in custom-tracks.draw.directive.ts and draw-ugc-poi.directive.ts.

- Replaced direct calls to `this._popoverRef.instance.message$.next(null)` with `this._updatePopoverMessage(null)` for consistency and encapsulation.
- In `clearTracks` method of `custom-tracks.draw.directive.ts`, added a check for feature count to determine when to update the popover message.
- Adjusted `wmMapDrawUgcPoiPoi` input setter in `draw-ugc-poi.directive.ts` to update the popover message based on the presence of a UGC POI and the enabled state.

These changes ensure that the popover message updates more accurately reflect the current state of the map features and user interactions.
