### PR TITLE
feat(styles): ✨ add toggle for track direction arrow oc: 5743

### DIFF
--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -831,7 +831,8 @@ export function styleFn(this: any, feature: RenderFeature, routing?: boolean) {
       lineString.setProperties(feature.getProperties());
       styles = [...styles, ...buildRefStyle.bind(this)(lineString, {map: this.map})];
     }
-    if (currentZoom > 11 && enableRouting === false) {
+    const showTrackDirectionArrow = this.conf?.show_track_direction_arrow ?? true;
+    if (showTrackDirectionArrow && currentZoom > 11 && enableRouting === false) {
       const lineString = getLineStringFromRenderFeature(feature);
       lineString.setProperties(feature.getProperties());
       styles = [


### PR DESCRIPTION
Introduce a configuration option `show_track_direction_arrow` to control the display of track direction arrows on the map. By default, the arrow is shown, but users can now disable it via configuration. This change enhances customization options for map styling.

- Added a check for `show_track_direction_arrow` in the `styleFn` function.
- The arrow will only be displayed if `show_track_direction_arrow` is true and other conditions are met.
