### PR TITLE
chore(directives): ✨ add configurable zoom features in viewport oc: 5742

### DIFF
--- a/src/directives/layer.directive.ts
+++ b/src/directives/layer.directive.ts
@@ -36,6 +36,7 @@ import {
   FEATURES_IN_VIEWPORT_ZOOM_MIN,
   FEATURES_IN_VIEWPORT_ZOOM_MAX,
 } from '@map-core/readonly/constants';
+import {ZoomFeaturesInViewport} from '@wm-types/config';
 
 @Directive({
   selector: '[wmMapLayer]',
@@ -53,6 +54,8 @@ export class WmMapLayerDirective extends WmMapBaseDirective implements OnChanges
   private _dataLayerUrls: IDATALAYER;
   private _disabled = false;
   private _opacity = 1;
+  private _minZoomFeaturesInViewport: number;
+  private _maxZoomFeaturesInViewport: number;
   private _vectorTileLayer: VectorTileLayer;
   private _moveEndSubject$: Subject<void> = new Subject<void>();
   private _moveEndListener: () => void;
@@ -113,6 +116,11 @@ export class WmMapLayerDirective extends WmMapBaseDirective implements OnChanges
       });
     }
     this._updateMap();
+  }
+
+  @Input() set wmMapLayerZoomFeaturesInViewport(zoom: ZoomFeaturesInViewport) {
+    this._minZoomFeaturesInViewport = zoom.minZoomFeaturesInViewport ?? FEATURES_IN_VIEWPORT_ZOOM_MIN;
+    this._maxZoomFeaturesInViewport = zoom.maxZoomFeaturesInViewport ?? FEATURES_IN_VIEWPORT_ZOOM_MAX;
   }
 
   /**
@@ -347,8 +355,8 @@ export class WmMapLayerDirective extends WmMapBaseDirective implements OnChanges
       const zoom = view.getZoom();
       if (
         this.wmMapLayerShowFeaturesInViewport &&
-        zoom >= FEATURES_IN_VIEWPORT_ZOOM_MIN &&
-        zoom <= FEATURES_IN_VIEWPORT_ZOOM_MAX
+        zoom >= this._minZoomFeaturesInViewport &&
+        zoom <= this._maxZoomFeaturesInViewport
       ) {
         this.mapCmp.map.on('moveend', this._moveEndListener);
       } else {


### PR DESCRIPTION
Added the ability to configure minimum and maximum zoom levels for features within the viewport in the `WmMapLayerDirective`. This allows for more flexible control over when features should be displayed based on the current zoom level.

- Introduced `wmMapLayerZoomFeaturesInViewport` input to set custom zoom levels.
- Default values fall back to `FEATURES_IN_VIEWPORT_ZOOM_MIN` and `FEATURES_IN_VIEWPORT_ZOOM_MAX` if not provided.
- Updated internal checks to use the configurable zoom levels.
