### PR TITLE
chore(utils): ✨ add geometry utility for closest point calculation oc:5741

### DIFF
--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -1,0 +1,14 @@
+import {Coordinate} from "ol/coordinate";
+import {WmFeature} from "@wm-types/feature";
+import {LineString} from "geojson";
+import {GeoJSON} from 'ol/format';
+
+export function getClosestPoint(feature: WmFeature<LineString>, coordinates: Coordinate): Coordinate | null {
+  const geometry = feature?.geometry;
+  if(!geometry) return null;
+
+  const format = new GeoJSON();
+  const geometryOl = format.readGeometry(geometry);
+
+  return geometryOl.getClosestPoint(coordinates);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './httpRequest';
 export * from './performance';
 export * from './logger';
 export * from './localForage';
+export * from './geometry';


### PR DESCRIPTION
Added a new utility function `getClosestPoint` in `geometry.ts` to calculate the closest point on a line string feature to a given coordinate. This function utilizes the OpenLayers library for geometry operations. Also updated `index.ts` to export the new geometry module.
