### PR TITLE
fix(styles): 🐛 correct arrow style rotation calculation oc:5673

### DIFF
--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -115,7 +115,7 @@ export function buildArrowStyle(
         image: new Icon({
           src: 'map-core/assets/line-icon-arrow.png',
           scale: scale,
-          rotation: point[2],
+          rotation: point[point.length - 1],
           color: opt.featureStrokeColor,
           rotateWithView: true,
         }),


### PR DESCRIPTION
Adjusted the arrow style rotation to use the last element in the `point` array instead of a fixed index to ensure the correct rotation value is applied. This fixes issues where the rotation was not being calculated correctly for dynamic points.
