### PR TITLE
chore(map): ✨ add toggle for map controls oc:5248

### DIFF
--- a/src/components/map/map.component.html
+++ b/src/components/map/map.component.html
@@ -33,6 +33,7 @@
     </div>
     <div class="top-right">
       <wm-map-controls
+        *ngIf="wmMapEnableMapControls"
         [conf]="(wmMapConf$|async)?.controls"
         [tileLayers]="tileLayers"
         [wmMapTranslationCallback]="translationCallback"

--- a/src/components/map/map.component.ts
+++ b/src/components/map/map.component.ts
@@ -74,6 +74,7 @@ export class WmMapComponent implements OnChanges, AfterViewInit, OnDestroy {
   };
   @Input() wmMapFullscreen: boolean = false;
   @Input() wmMapOnly: boolean = false;
+  @Input() wmMapEnableMapControls: boolean = false;
   @Input() wmMapPadding: number[] | null;
   @Output() clickEVT$: EventEmitter<MapBrowserEvent<UIEvent>> = new EventEmitter<
     MapBrowserEvent<UIEvent>


### PR DESCRIPTION
Added a new input property `wmMapEnableMapControls` to the `WmMapComponent`. This allows toggling the visibility of the map controls dynamically. By default, the controls are disabled. This change provides more flexibility in customizing the map interface based on user needs or application state.
