### PR TITLE
chore(utils): ✨ add distance calculation and optimize arrow filtering oc:5800

### DIFF
--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -12,3 +12,10 @@ export function getClosestPoint(feature: WmFeature<LineString>, coordinates: Coo
 
   return geometryOl.getClosestPoint(coordinates);
 }
+
+export function calculateDistance(point1: Coordinate, point2: Coordinate): number {
+  const dx = point1[0] - point2[0];
+  const dy = point1[1] - point2[1];
+  return Math.sqrt(dx * dx + dy * dy);
+}
+

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -13,6 +13,8 @@ import RenderFeature, {toFeature} from 'ol/render/Feature';
 import {Coordinate} from 'ol/coordinate';
 import {containsCoordinate} from 'ol/extent';
 import {ILAYER} from '@map-core/types/layer';
+import {calculateDistance, getClosestPoint} from './geometry';
+import {transform} from 'ol/proj';
 
 export interface handlingStrokeStyleWidthOptions {
   currentZoom: number;
@@ -816,12 +818,13 @@ export function styleFn(this: any, feature: RenderFeature, routing?: boolean) {
   };
   handlingStrokeStyleWidth(opt);
 
-  let styles = [
+  let styles: Style[] = [
     new Style({
       stroke: strokeStyle,
       zIndex: TRACK_ZINDEX + 1,
     }),
   ];
+  let arrowStyle: Style[] = [];
   if (strokeStyle?.getColor() != 'rgba(0,0,0,0)') {
     if (this.conf.start_end_icons_show && currentZoom > this.conf.start_end_icons_min_zoom) {
       styles = [...styles, ...buildStartEndIcons(geometry)];
@@ -835,16 +838,49 @@ export function styleFn(this: any, feature: RenderFeature, routing?: boolean) {
     if (showTrackDirectionArrow && currentZoom > 11 && enableRouting === false) {
       const lineString = getLineStringFromRenderFeature(feature);
       lineString.setProperties(feature.getProperties());
-      styles = [
-        ...styles,
-        ...buildArrowStyle.bind(this)(lineString, {
-          map: this.map,
-          width: strokeStyle.getWidth() - 1,
-        }),
-      ];
+
+      // Pre-calcola le frecce
+      const allArrowStyles = buildArrowStyle.bind(this)(lineString, {
+        map: this.map,
+        width: strokeStyle.getWidth() - 1,
+      });
+
+      // Ottimizzazione del filtro per currentTrack
+      if (this.currentTrack && this.currentTrack.geometry) {
+        const resolution = this.map.getView().getResolution();
+        const threshold = resolution * 5;
+
+        // Filtra gli stili delle frecce che ricadono nella geometria di currentTrack
+        arrowStyle = allArrowStyles.filter(style => {
+          const pointGeometry = style.getGeometry();
+          if (!(pointGeometry instanceof Point)) {
+            return true; // Mantieni stili non-punto
+          }
+
+          const pointCoords = pointGeometry.getCoordinates();
+
+          // Trasforma pointCoords dal sistema di coordinate della mappa (EPSG:3857) a WGS84 (EPSG:4326)
+          const pointCoordsWGS84 = transform(pointCoords, 'EPSG:3857', 'EPSG:4326');
+
+          // Usa la funzione helper per calcolare il punto più vicino (che lavora in WGS84)
+          const closestPoint = getClosestPoint(this.currentTrack, pointCoordsWGS84);
+          if (!closestPoint) {
+            return true; // Se currentTrack non è presente, mantieni il punto
+          }
+          // Trasforma il punto più vicino da WGS84 al sistema di coordinate della mappa
+          const closestPointMap = transform(closestPoint, 'EPSG:4326', 'EPSG:3857');
+
+          const distance = calculateDistance(pointCoords, closestPointMap);
+
+          // Rimuovi i punti che sono troppo vicini a currentTrack
+          return distance > threshold;
+        });
+      } else {
+        arrowStyle = allArrowStyles;
+      }
     }
   }
-  return styles;
+  return [...styles, ...arrowStyle];
 }
 
 /**


### PR DESCRIPTION
Added a new utility function `calculateDistance` to compute the Euclidean distance between two points. This function is now used in `styles.ts` to optimize the filtering of arrow styles based on their proximity to the current track.

- Introduced `calculateDistance` in `geometry.ts` for computing distances between coordinates.
- Updated `styleFn` in `styles.ts` to filter arrow styles more efficiently, using the distance calculation to remove points too close to `currentTrack`.
- Integrated coordinate transformations to ensure accurate distance measurements in the map's coordinate system.

These enhancements improve performance by minimizing unnecessary rendering of arrow styles that are too close to the current track, particularly when the track is displayed without routing.
