### PR TITLE
chore(map): ✨ display tile size on bounding box oc:6133

### DIFF
--- a/src/directives/tiles-download.directive.ts
+++ b/src/directives/tiles-download.directive.ts
@@ -27,6 +27,7 @@ import {
   FEATURE_COLLECTION_ZINDEX,
   TILES_DOWNLOAD_ZOOM_MIN,
 } from '@map-core/readonly';
+import {Text} from 'ol/style';
 
 @Directive({
   selector: '[wmMapTilesDownload]',
@@ -285,6 +286,9 @@ export class WmMapTilesDownloadDirective extends WmMapBaseDirective implements O
   }
 
   private _boundingBoxStyle(feature: Feature): Style {
+    const size = feature.get('size');
+    const sizeText =
+      size > 1000000 ? `${Math.round(size / 1000000)} MB` : `${Math.round(size / 1000)} KB`;
     const baseStyle = {
       stroke: new Stroke({
         color: 'rgba(231, 67, 58,0.5)',
@@ -292,6 +296,19 @@ export class WmMapTilesDownloadDirective extends WmMapBaseDirective implements O
       }),
       fill: new Fill({
         color: 'rgba(231, 240, 58,0.5)',
+      }),
+      text: new Text({
+        text: sizeText,
+        font: '12px Calibri,sans-serif',
+        textAlign: 'center',
+        textBaseline: 'middle',
+        fill: new Fill({
+          color: '#000',
+        }),
+        stroke: new Stroke({
+          color: '#fff',
+          width: 3,
+        }),
       }),
     };
     return new Style(baseStyle);

--- a/src/utils/localForage.ts
+++ b/src/utils/localForage.ts
@@ -207,15 +207,18 @@ export async function downloadTilesByBoundingBox(
     GET_TILES_BY_GEOMETRY_MAX_ZOOM,
   );
   const totalTiles = tiles.length;
+  let totalSize = 0;
 
   for (let i = 0; i < totalTiles; i++) {
     const tile = tiles[i];
     const wmTilesAPI = `${overlayXYZ}/${tile}.png`;
     const tileData = await downloadFile(wmTilesAPI);
+    totalSize += tileData?.byteLength ?? 0;
     await saveTile(tile, tileData, uuid);
     callBackStatusFn({
       finish: false,
       map: (i + 1) / totalTiles, // percentuale avanzamento
+      size: totalSize,
     });
   }
 
@@ -225,6 +228,7 @@ export async function downloadTilesByBoundingBox(
       ...boundingBox.properties,
       idsTiles: tiles,
       uuid,
+      size: totalSize,
     },
   };
   await saveBoundingBox(boundingBoxWithIdsTiles);
@@ -334,6 +338,7 @@ export function updateStatus(status: {
   map?: number;
   media?: number;
   data?: number;
+  size?: number;
 }): void {
   console.log('Status update:', status);
 }


### PR DESCRIPTION
Added a feature to display the size of downloaded tiles on the bounding box in the map interface. The size is shown in MB or KB, depending on its magnitude.

- Imported `Text` style from OpenLayers.
- Updated `_boundingBoxStyle` to include text that displays the size of the downloaded tiles.
- In `downloadTilesByBoundingBox`, calculated the total size of the downloaded tiles and passed it to the status callback.
- Added a `size` property to the bounding box metadata for display purposes.
