### PR TITLE
feat(directive): ✨ implement hover feature highlighting in map layer oc:7161

### DIFF
--- a/src/directives/layer.directive.ts
+++ b/src/directives/layer.directive.ts
@@ -13,6 +13,7 @@ import VectorTileLayer from 'ol/layer/VectorTile';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import GeoJSON from 'ol/format/GeoJSON';
+import RenderFeature, {toFeature} from 'ol/render/Feature';
 
 import {debounceTime, filter, take} from 'rxjs/operators';
 import {Subject} from 'rxjs';
@@ -36,6 +37,7 @@ import {
   MAP_ZOOM_ON_CLICK_TRESHOLD,
   FEATURES_IN_VIEWPORT_ZOOM_MIN,
   FEATURES_IN_VIEWPORT_ZOOM_MAX,
+  MIN_ZOOM_FOR_HOVER,
 } from '@map-core/readonly/constants';
 import {ZoomFeaturesInViewport} from '@wm-types/config';
 
@@ -60,6 +62,10 @@ export class WmMapLayerDirective extends WmMapBaseDirective implements OnChanges
   private _vectorTileLayer: VectorTileLayer;
   private _moveEndSubject$: Subject<void> = new Subject<void>();
   private _moveEndListener: () => void;
+  private _hoveredFeatureId: number | null = null;
+  private _hoverHandlerInitialized = false;
+  private _pointerMoveListener: (e: any) => void;
+  private _resolutionChangeListenerInitialized = false;
 
   /**
    * @description
@@ -152,17 +158,14 @@ export class WmMapLayerDirective extends WmMapBaseDirective implements OnChanges
         take(1),
       )
       .subscribe(() => {
-        const view = this.mapCmp.map.getView();
         if (enable) {
           this._moveEndSubject$.pipe(debounceTime(100)).subscribe(() => {
             this._featuresInViewport();
           });
           this._moveEndListener = () => this._moveEndSubject$.next();
-          view.on('change:resolution', this._enableFeaturesInViewportCallback);
+          this._initResolutionChangeListener();
         } else {
-          this.wmMapLayerShowFeaturesInViewport = false;
-          this._enableFeaturesInViewportCallback();
-          view.un('change:resolution', this._enableFeaturesInViewportCallback);
+          this._removeMoveEndListenerIfExists();
         }
       });
   }
@@ -284,27 +287,43 @@ export class WmMapLayerDirective extends WmMapBaseDirective implements OnChanges
    */
   private _initializeDataLayers(map: IMAP): void {
     if (this._dataLayerUrls != null) {
+      // Crea un oggetto wrapper per mantenere il riferimento alla direttiva
+      // così styleFn può accedere a _hoveredFeatureId aggiornato
+      const directiveRef = this;
+      const styleFnContext = {
+        currentLayer: this._currentLayer,
+        conf: this.wmMapConf,
+        map: this.mapCmp.map,
+        opacity: this.wmMapLayerOpacity,
+        filters: this.mapCmp.filters,
+        tileLayer: null as VectorTileLayer, // Verrà aggiornato dopo
+        inputTyped: this.wmMapInputTyped,
+        currentTrack: convertFeatureToEpsg3857(this.track),
+        get hoveredFeatureId() {
+          return directiveRef._hoveredFeatureId;
+        },
+      };
+
       this._vectorTileLayer = initVectorTileLayer(
         this._dataLayerUrls.low,
-        f =>
-          styleFn.bind({
-            currentLayer: this._currentLayer,
-            conf: this.wmMapConf,
-            map: this.mapCmp.map,
-            opacity: this.wmMapLayerOpacity,
-            filters: this.mapCmp.filters,
-            tileLayer: this._vectorTileLayer,
-            inputTyped: this.wmMapInputTyped,
-            currentTrack: convertFeatureToEpsg3857(this.track),
-          })(f),
+        f => styleFn.bind(styleFnContext)(f),
         lowTileLoadFn,
       );
+
+      // Aggiorna il riferimento al tileLayer nel contesto
+      styleFnContext.tileLayer = this._vectorTileLayer;
 
       this.mapCmp.map.addLayer(this._vectorTileLayer);
       this._vectorTileLayer.setVisible(!this._disabled);
       this.mapCmp.map.on('click', (evt: any) => {
         this.onClick(evt);
       });
+      this._initHoverHandler();
+
+      // Inizializza il listener unificato per i cambiamenti di zoom
+      this._initResolutionChangeListener();
+      // Controlla lo zoom iniziale
+      this._onResolutionChange();
     }
   }
 
@@ -350,6 +369,43 @@ export class WmMapLayerDirective extends WmMapBaseDirective implements OnChanges
     this.featuresInViewportEVT.emit(features);
   }
 
+  /**
+   * @description
+   * Inizializza il listener unificato per i cambiamenti di risoluzione (zoom).
+   * Questo listener gestisce sia il features in viewport che l'hover handler.
+   * @private
+   * @memberof WmMapLayerDirective
+   */
+  private _initResolutionChangeListener(): void {
+    if (this._resolutionChangeListenerInitialized) {
+      return;
+    }
+
+    const view = this.mapCmp.map.getView();
+    view.on('change:resolution', this._onResolutionChange);
+    this._resolutionChangeListenerInitialized = true;
+  }
+
+  /**
+   * @description
+   * Callback unificato chiamato quando cambia la risoluzione (zoom).
+   * Gestisce sia il features in viewport che l'hover handler.
+   * @private
+   * @memberof WmMapLayerDirective
+   */
+  private _onResolutionChange = () => {
+    // Gestisce il features in viewport
+    this._enableFeaturesInViewportCallback();
+    // Gestisce l'hover handler
+    this._enableHoverHandlerCallback();
+  };
+
+  /**
+   * @description
+   * Callback che abilita/disabilita il features in viewport in base allo zoom.
+   * @private
+   * @memberof WmMapLayerDirective
+   */
   private _enableFeaturesInViewportCallback = () => {
     try {
       const view = this.mapCmp.map.getView();
@@ -361,15 +417,144 @@ export class WmMapLayerDirective extends WmMapBaseDirective implements OnChanges
       ) {
         this.mapCmp.map.on('moveend', this._moveEndListener);
       } else {
-        const listeners = this.mapCmp.map.getListeners('moveend');
-        if (listeners && listeners.length > 0) {
-          this.mapCmp.map.un('moveend', this._moveEndListener);
-        }
-        this.featuresInViewportEVT.emit([]);
+        this._removeMoveEndListenerIfExists();
       }
     } catch (e) {
       console.log(e);
       this.featuresInViewportEVT.emit([]);
     }
   };
+
+  /**
+   * @description
+   * Callback che abilita/disabilita il gestore del mouseover in base allo zoom.
+   * Il hover handler è attivo solo quando lo zoom è >= 8.
+   * @private
+   * @memberof WmMapLayerDirective
+   */
+  private _enableHoverHandlerCallback = () => {
+    if (!this._vectorTileLayer) {
+      return;
+    }
+
+    const view = this.mapCmp.map.getView();
+    const zoom = view.getZoom();
+
+    if (zoom >= MIN_ZOOM_FOR_HOVER) {
+      // Zoom sufficiente: aggiungi il listener se non è già presente
+      if (!this._hoverHandlerInitialized) {
+        this._initHoverHandler();
+      }
+    } else {
+      // Zoom insufficiente: rimuovi il listener se presente
+      if (this._hoverHandlerInitialized && this._pointerMoveListener) {
+        this.mapCmp.map.un('pointermove', this._pointerMoveListener);
+        this._hoverHandlerInitialized = false;
+        // Reset dello stato hover
+        if (this._hoveredFeatureId !== null) {
+          this._hoveredFeatureId = null;
+          this._vectorTileLayer.changed();
+        }
+        const viewport = this.mapCmp.map.getViewport();
+        if (viewport.style.cursor !== '') {
+          viewport.style.cursor = '';
+        }
+      }
+    }
+  };
+
+  private _removeMoveEndListenerIfExists(): void {
+    const listeners = this.mapCmp.map.getListeners('moveend');
+    if (listeners && listeners.length > 0) {
+      this.mapCmp.map.un('moveend', this._moveEndListener);
+    }
+    this.featuresInViewportEVT.emit([]);
+  }
+  /**
+   * @description
+   * Inizializza il gestore del mouseover per le tracce.
+   * Rileva quando il mouse è sopra una traccia e aggiorna _hoveredFeatureId per attivare il bordo bianco.
+   * Ottimizzato per evitare listener duplicati e chiamate inutili a changed().
+   * @private
+   * @memberof WmMapLayerDirective
+   */
+  private _initHoverHandler(): void {
+    if (!this._vectorTileLayer || this._hoverHandlerInitialized) {
+      return;
+    }
+
+    this._hoverHandlerInitialized = true;
+    const viewport = this.mapCmp.map.getViewport();
+
+    this._pointerMoveListener = (e: any) => {
+      if (!this._vectorTileLayer) {
+        return;
+      }
+
+      // Verifica che lo zoom sia ancora sufficiente
+      const view = this.mapCmp.map.getView();
+      const zoom = view.getZoom();
+      if (zoom < MIN_ZOOM_FOR_HOVER) {
+        return;
+      }
+
+      let foundFeatureId: number | null = null;
+
+      // Cerca la feature sotto il pixel del mouse
+      this.mapCmp.map.forEachFeatureAtPixel(
+        e.pixel,
+        (f: RenderFeature, l: VectorTileLayer) => {
+          // Verifica che la feature appartenga al layer delle tracce
+          if (l === this._vectorTileLayer && f.getType != null) {
+            try {
+              const feature = toFeature(f);
+              const properties = feature.getProperties();
+              const featureId: number = properties?.id ?? undefined;
+              const geometryType = feature.getGeometry()?.getType();
+
+              // Applica l'highlight alle LineString e MultiLineString (tracce)
+              if (
+                (geometryType === 'LineString' || geometryType === 'MultiLineString') &&
+                featureId != null &&
+                featureId > -1
+              ) {
+                foundFeatureId = featureId;
+                return true;
+              }
+            } catch (_) {
+              // Ignora errori nella conversione della feature
+            }
+          }
+        },
+        {
+          hitTolerance: 10,
+          layerFilter: layer => layer === this._vectorTileLayer,
+        },
+      );
+
+      // Aggiorna lo stato solo se è cambiato
+      if (foundFeatureId !== null) {
+        // Feature trovata
+        if (this._hoveredFeatureId !== foundFeatureId) {
+          this._hoveredFeatureId = foundFeatureId;
+          this._vectorTileLayer.changed();
+        }
+        if (viewport.style.cursor !== 'pointer') {
+          viewport.style.cursor = 'pointer';
+        }
+      } else {
+        // Nessuna feature trovata
+        if (this._hoveredFeatureId !== null) {
+          this._hoveredFeatureId = null;
+          this._vectorTileLayer.changed();
+        }
+        if (viewport.style.cursor !== '') {
+          viewport.style.cursor = '';
+        }
+      }
+    };
+
+    this.mapCmp.map.on('pointermove', this._pointerMoveListener);
+  }
+
 }

--- a/src/readonly/constants.ts
+++ b/src/readonly/constants.ts
@@ -26,3 +26,4 @@ export const BOX_SIZE_VMIN = 65;
 export const TILES_DOWNLOAD_ZOOM_MIN = 10;
 export const GET_TILES_BY_GEOMETRY_MIN_ZOOM = 5;
 export const GET_TILES_BY_GEOMETRY_MAX_ZOOM = 16;
+export const MIN_ZOOM_FOR_HOVER = 10;

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -812,12 +812,63 @@ export function styleFn(this: any, feature: RenderFeature, routing?: boolean) {
   };
   handlingStrokeStyleWidth(opt);
 
-  let styles: Style[] = [
-    new Style({
-      stroke: strokeStyle,
-      zIndex: TRACK_ZINDEX + 1,
-    }),
-  ];
+  let styles: Style[] = [];
+
+  // Aggiungi bordo bianco esterno se la feature è in hover
+  const featureId: number = properties?.id ?? undefined;
+  const geometryType = feature.getGeometry().getType();
+  const isHovered =
+    this.hoveredFeatureId != null &&
+    featureId != null &&
+    featureId === this.hoveredFeatureId &&
+    (geometryType === 'LineString' || geometryType === 'MultiLineString');
+
+  if (isHovered && strokeStyle?.getColor() != 'rgba(0,0,0,0)') {
+    // Ottieni la larghezza della traccia originale
+    const originalWidth = strokeStyle.getWidth() ?? minStrokeWidth;
+    const originalColor = strokeStyle.getColor() as string;
+    const mainLineWidth = originalWidth + 2;
+    const borderWidth = mainLineWidth + 4;
+
+    // 1. Bordo esterno (disegnato per primo, zIndex più basso)
+    styles.push(
+      new Style({
+        stroke: new Stroke({
+          color: '#ffffff',
+          width: borderWidth,
+          lineCap: strokeStyle.getLineCap() ?? 'round',
+          lineJoin: strokeStyle.getLineJoin() ?? 'round',
+          lineDash: strokeStyle.getLineDash() ?? [],
+        }),
+        zIndex: TRACK_ZINDEX + 1,
+      }),
+    );
+
+    // 2. Linea principale (disegnata sopra, zIndex più alto)
+    // Crea un nuovo StrokeStyle con la larghezza aumentata
+    const mainLineStroke = new Stroke({
+      color: originalColor,
+      width: mainLineWidth,
+      lineCap: strokeStyle.getLineCap() ?? 'round',
+      lineJoin: strokeStyle.getLineJoin() ?? 'round',
+      lineDash: strokeStyle.getLineDash() ?? [],
+    });
+
+    styles.push(
+      new Style({
+        stroke: mainLineStroke,
+        zIndex: TRACK_ZINDEX + 2,
+      }),
+    );
+  } else {
+    // Se non è in hover, usa la traccia originale normale
+    styles.push(
+      new Style({
+        stroke: strokeStyle,
+        zIndex: TRACK_ZINDEX + 1,
+      }),
+    );
+  }
   let arrowStyle: Style[] = [];
   if (strokeStyle?.getColor() != 'rgba(0,0,0,0)') {
     if (this.conf.start_end_icons_show && currentZoom > this.conf.start_end_icons_min_zoom) {


### PR DESCRIPTION
Added functionality to highlight features on hover within the `WmMapLayerDirective`. Introduced a hover handler that updates the `_hoveredFeatureId` based on mouse movements over the vector tile layer. Enhanced the `styleFn` to apply a white border to hovered features, specifically for `LineString` and `MultiLineString` geometries, improving user interaction and visual feedback on the map.
