### PR TITLE
fix(oc:8114): rimuovi flash visivo ECPOI all'avvio app

### DIFF
--- a/docs/features/8114-fix-flash-visivo-ecpoi-avvio-app/notes.md
+++ b/docs/features/8114-fix-flash-visivo-ecpoi-avvio-app/notes.md
@@ -1,0 +1,20 @@
+> Ticket: oc:8114
+
+# Notes — Fix flash visivo ECPOI all'avvio app
+
+## Deviazioni dal piano
+
+Nessuna deviazione rispetto al piano approvato.
+
+## Bug trovati
+
+Nessun bug aggiuntivo scoperto durante l'implementazione.
+
+## Decisioni
+
+- Non è stato scritto un test automatico: i directive spec non girano in CI (richiedono browser con GPU) e il fix è verificabile più efficacemente in modo visivo.
+
+## Follow-up
+
+- `apppoisApiLayer` (campo `IPOI` in `map-core/src/types/model.ts`) non è attualmente letto da nessuna parte nel codice. Dovrebbe essere incluso in `wmMapEcPoisDisableLayer$` in `wm-core/geobox-map/geobox-map.component.ts` per disabilitare completamente la directive quando la conf non prevede POI globali. Da tracciare in ticket separato.
+- Il setter `_disableClusterLayer` chiama `setVisible(!disabled)` ignorando lo zoom: se `disabled` torna `false` mentre lo zoom è sotto `poisMinZoom`, il layer diventa visibile scorrettamente. Bug pre-esistente, fuori scope di questo ticket.

--- a/docs/features/8114-fix-flash-visivo-ecpoi-avvio-app/overview.md
+++ b/docs/features/8114-fix-flash-visivo-ecpoi-avvio-app/overview.md
@@ -1,0 +1,42 @@
+> Ticket: oc:8114
+
+# Fix flash visivo ECPOI all'avvio app
+
+## Cosa cambia
+
+Il layer dei POI globali (`_poisClusterLayer`) non sarà più visibile per un frame prima che il range minimo venga applicato. La visibilità iniziale sarà determinata in un unico momento combinando entrambe le condizioni (`!disabled && zoom >= poisMinZoom`).
+
+## Perché
+
+In `_initDirective` (file `pois.directive.ts`), la sequenza attuale è:
+
+1. `createCluster` → layer creato con `visible: true` (default OL)
+2. `_checkZoom` chiamato → nasconde il layer se zoom < `poisMinZoom` ✅
+3. `map.addLayer` → layer aggiunto alla mappa
+4. `setVisible(!this._disabled)` → sovrascrive il risultato di `_checkZoom`, rendendo il layer visibile indipendentemente dallo zoom 🐛
+
+Al primo `moveend` successivo `_checkZoom` viene chiamato di nuovo e nasconde correttamente i POI — ma nel frattempo sono già stati renderizzati per almeno un frame, causando il flash visivo.
+
+## Requisiti
+
+- [ ] Il layer `_poisClusterLayer` deve partire con `visible: false` subito dopo la creazione
+- [ ] La visibilità iniziale deve essere impostata una sola volta, come risultato di `_checkZoom`, che già combina zoom e stato disabled
+- [ ] La riga `this._poisClusterLayer?.setVisible(!this._disabled)` in `_initDirective` va rimossa o sostituita con una condizione combinata
+- [ ] Il comportamento post-init (cambio di `_disabled` o cambio di zoom via `moveend`) non deve essere alterato
+
+## Rischi
+
+- **Regressione su disabled=true all'init:** se `_disabled` fosse già `true` quando `_initDirective` gira, rimuovere la riga 396 lascerebbe il layer nascosto (corretto) ma `_checkZoom` non lo renderebbe mai visibile nemmeno se disabled tornasse `false` — tuttavia il setter `wmMapPoisDisableClusterLayer` chiama già `setVisible(!disabled)` per i cambiamenti post-init, quindi questo caso è coperto.
+- **`createCluster` condiviso:** `ugc-pois.directive.ts` usa la stessa factory — il fix deve essere localizzato in `pois.directive.ts` senza toccare la firma di `createCluster`.
+
+## Out of scope
+
+- Fix del listener `moveend` (vs `change:resolution`) — comportamento separato, non causa del flash
+- Modifica alla directive UGC POI
+- Qualsiasi modifica al parametro `poisMinZoom` o alla configurazione
+
+## Moduli toccati
+
+| File | Repo |
+|------|------|
+| `src/directives/pois.directive.ts` | `map-core` |

--- a/docs/features/8114-fix-flash-visivo-ecpoi-avvio-app/plan.md
+++ b/docs/features/8114-fix-flash-visivo-ecpoi-avvio-app/plan.md
@@ -1,0 +1,128 @@
+> Ticket: oc:8114
+
+# Fix flash visivo ECPOI all'avvio app — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminare il flash visivo dei POI globali all'avvio della mappa impostando la visibilità iniziale del layer in un unico momento, come risultato della condizione combinata `!disabled && zoom >= poisMinZoom`.
+
+**Architecture:** Il layer `_poisClusterLayer` parte con `visible: false` immediatamente dopo la creazione. `_checkZoom` è l'unica funzione che imposta la visibilità — sia all'init che su `moveend`. Un secondo `_checkZoom` su `map.once('rendercomplete')` copre il caso in cui `wmMapConf` non sia ancora disponibile al momento dell'init.
+
+**Tech Stack:** Angular 20, OpenLayers 7, TypeScript (strict), Karma + Jasmine (test)
+
+## Global Constraints
+
+- File unico toccato: `src/directives/pois.directive.ts` nel submodule `map-core`
+- Non modificare la firma di `createCluster` in `utils/ol.ts`
+- Non toccare `ugc-pois.directive.ts`
+- Commit convention: `fix(oc:8114): ...`
+- Test runner: `nvm use 22 && npx ng test map-core` (locale) oppure `CI=true npx ng test map-core --configuration=ci` (CI, solo 27 spec utils)
+
+---
+
+### Task 1: Rimuovere il flash — fix in `_initDirective`
+
+**Files:**
+- Modify: `src/directives/pois.directive.ts:367-397`
+
+**Interfaces:**
+- Consumes: `_poisClusterLayer` (VectorLayer<Cluster>), `_checkZoom(layer)`, `mapCmp.map`
+- Produces: layer che parte `visible: false` e viene mostrato solo dopo `_checkZoom`
+
+Il metodo `_initDirective` attuale (righe 367-397) ha questa sequenza problematica:
+
+```typescript
+// PRIMA (bug):
+this._poisClusterLayer = createCluster(this._poisClusterLayer, CLUSTER_ZINDEX); // visible: true (OL default)
+// ...
+this._checkZoom(this._poisClusterLayer);          // riga 390: nasconde se zoom < minZoom ✅
+this.mapCmp.map.addLayer(this._poisClusterLayer); // riga 391
+// ...
+this._poisClusterLayer?.setVisible(!this._disabled); // riga 396: sovrascrive _checkZoom 🐛
+```
+
+- [ ] **Step 1: Imposta `visible: false` subito dopo `createCluster`**
+
+In `src/directives/pois.directive.ts`, nel metodo `_initDirective`, aggiungi una riga dopo la riga 369:
+
+```typescript
+this._poisClusterLayer = createCluster(this._poisClusterLayer, CLUSTER_ZINDEX);
+this._poisClusterLayer.setVisible(false); // ← aggiungi questa riga
+```
+
+- [ ] **Step 2: Rimuovi la riga 396 (`setVisible(!this._disabled)`)**
+
+Elimina completamente questa riga da `_initDirective`:
+
+```typescript
+// RIMUOVERE:
+this._poisClusterLayer?.setVisible(!this._disabled);
+```
+
+- [ ] **Step 3: Aggiungi il safeguard `rendercomplete`**
+
+Dopo `this.mapCmp.map.addLayer(this._poisClusterLayer)` (riga 391), aggiungi:
+
+```typescript
+this.mapCmp.map.once('rendercomplete', () => {
+  this._checkZoom(this._poisClusterLayer);
+});
+```
+
+Questo copre il caso in cui `wmMapConf` fosse `null` al momento della chiamata `_checkZoom` a riga 390 (la guard `if (view != null && this.wmMapConf != null)` in `_checkZoom` avrebbe saltato il check).
+
+Il risultato finale del metodo `_initDirective` deve essere:
+
+```typescript
+private _initDirective(): void {
+  this._selectedPoiLayer = createLayer(this._selectedPoiLayer, FLAG_TRACK_ZINDEX + 100);
+  this._poisClusterLayer = createCluster(this._poisClusterLayer, CLUSTER_ZINDEX);
+  this._poisClusterLayer.setVisible(false); // parte nascosto
+  const clusterSource: Cluster = this._poisClusterLayer.getSource();
+  this._hullClusterLayer = new VectorLayer({
+    style: clusterHullStyle,
+    source: clusterSource,
+  });
+  this._selectCluster = createHull();
+  this._popupOverlay = new Popup({
+    popupClass: 'default anim',
+    closeBox: true,
+    offset: [0, -16],
+    positioning: 'bottom-center',
+    onclose: () => {
+      clearLayer(this._selectedPoiLayer);
+    },
+    autoPan: {
+      animation: {
+        duration: 100,
+      },
+    },
+  });
+  this._checkZoom(this._poisClusterLayer); // imposta visibilità basata su zoom
+  this.mapCmp.map.addLayer(this._poisClusterLayer);
+  this.mapCmp.map.addLayer(this._hullClusterLayer);
+  this.mapCmp.map.addLayer(this._selectedPoiLayer);
+  this.mapCmp.map.addOverlay(this._popupOverlay);
+  this.mapCmp.map.once('rendercomplete', () => {
+    this._checkZoom(this._poisClusterLayer); // safeguard se wmMapConf era null al primo check
+  });
+  this.mapCmp.registerDirective(this._poisClusterLayer['ol_uid'], this);
+  // riga 396 RIMOSSA: setVisible(!this._disabled) non serve più
+}
+```
+
+- [ ] **Step 4: Verifica manuale**
+
+Avvia il dev server:
+```bash
+cd core && npm start
+```
+Apri `http://localhost:4200`, osserva la mappa all'avvio. I POI globali **non devono apparire** se lo zoom iniziale è sotto `poisMinZoom` (default 15). Zoomando sopra la soglia devono comparire correttamente.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd core/src/app/shared/map-core
+git add src/directives/pois.directive.ts
+git commit -m "fix(oc:8114): rimuovi flash visivo ECPOI impostando visible:false all'init"
+```

--- a/src/directives/pois.directive.ts
+++ b/src/directives/pois.directive.ts
@@ -367,6 +367,7 @@ export class WmMapPoisDirective extends WmMapBaseDirective implements OnChanges 
   private _initDirective(): void {
     this._selectedPoiLayer = createLayer(this._selectedPoiLayer, FLAG_TRACK_ZINDEX + 100);
     this._poisClusterLayer = createCluster(this._poisClusterLayer, CLUSTER_ZINDEX);
+    this._poisClusterLayer.setVisible(false);
     const clusterSource: Cluster = this._poisClusterLayer.getSource();
     this._hullClusterLayer = new VectorLayer({
       style: clusterHullStyle,
@@ -392,8 +393,10 @@ export class WmMapPoisDirective extends WmMapBaseDirective implements OnChanges 
     this.mapCmp.map.addLayer(this._hullClusterLayer);
     this.mapCmp.map.addLayer(this._selectedPoiLayer);
     this.mapCmp.map.addOverlay(this._popupOverlay);
+    this.mapCmp.map.once('rendercomplete', () => {
+      this._checkZoom(this._poisClusterLayer);
+    });
     this.mapCmp.registerDirective(this._poisClusterLayer['ol_uid'], this);
-    this._poisClusterLayer?.setVisible(!this._disabled);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Il layer `_poisClusterLayer` partiva con `visible:true` (default OL), `_checkZoom` lo nascondeva, ma `setVisible(!disabled)` lo ri-mostrava immediatamente sovrascrivendo il risultato — causando un flash visivo dei POI globali all'avvio
- Fix: il layer parte con `visible:false`, `_checkZoom` è l'unica fonte di verità sulla visibilità iniziale
- Aggiunto `map.once('rendercomplete')` come safeguard per il caso in cui `wmMapConf` fosse null al primo check

## Test plan

- [ ] Avviare l'app e verificare che i POI globali non appaiano brevemente all'avvio se lo zoom iniziale è sotto `poisMinZoom`
- [ ] Zoomare sopra `poisMinZoom` e verificare che i POI compaiano correttamente
- [ ] Verificare che i POI scompaiano tornando sotto `poisMinZoom`

Ticket: oc:8114

🤖 Generated with [Claude Code](https://claude.com/claude-code)