### PR TITLE
fix(oc:4783): apply wmMapPadding to geojson directive fit()

### DIFF
--- a/docs/features/4783-controllare-il-padding-della-mappa/notes.md
+++ b/docs/features/4783-controllare-il-padding-della-mappa/notes.md
@@ -1,0 +1,34 @@
+> Ticket: oc:4783
+
+# Notes — Controllare il padding della mappa
+
+## Deviazioni dal piano
+
+- **Step 1 (verifica empirica preliminare) non eseguito come da piano originale.** Il piano prevedeva un repro manuale in browser fatto da me; ho invece tentato prima un test Karma temporaneo (`_temp-padding-race.spec.ts`, poi rimosso) per verificare se `_handleWmMapPaddingChange` (`map.component.ts:332-339`) competesse col fit del geojson. Il test è fallito per un limite noto dell'ambiente sandbox: Chrome (sia headless che non, sia con che senza sandbox disabilitata) va in crash anche su un componente Angular banale senza `wm-map`/OpenLayers — non è quindi lo specifico problema GPU/OlMap già documentato in questo `CLAUDE.md` per i test directive/component, ma un limite più generale dell'ambiente di esecuzione di Claude Code per Chrome/Karma. Ho quindi verificato analiticamente (comportamento di hoisting delle costanti letterali nel compilatore Ivy di Angular, confermato via ricerca su PR ufficiali Angular) che un array literal come `[20, 20, 20, 20]` non cambia reference tra cicli di change detection per la stessa istanza di componente, quindi `_handleWmMapPaddingChange` non si attiva mai per questo binding statico (perché `_view` non esiste ancora al momento dell'unico `ngOnChanges` che riceve il valore). **La conferma definitiva è stata empirica dal developer**: ha riprodotto il bug a mano in `modal-ugc-uploader` e confermato che (a) prima del fix il padding non aveva alcun effetto e non c'era alcun salto/ricentraggio, (b) dopo il fix il padding funziona correttamente. Questo conferma sia la diagnosi originale sia l'assenza della race ipotizzata in Fase: challenge.
+- **Test Karma (`geojson.directive.spec.ts`) scritto ma non eseguito da me.** Per lo stesso limite ambientale (Chrome/Karma non avviabile in questo sandbox), non ho potuto lanciare la suite. Il file è stato scritto seguendo lo stile di `base.directive.spec.ts` e copre: padding passato correttamente, padding `undefined` quando non impostato, `maxZoom`/`duration` invariati. **Da eseguire dal developer in locale** con `nvm use 22 && npx ng test map-core --include='**/geojson.directive.spec.ts'` prima del merge, per conferma definitiva.
+- **Branch creato dopo la scrittura di `overview.md`/`plan.md`, come da ordine di fase previsto dal workflow** (non è una deviazione, ma lo noto per chiarezza: l'ordine "docs prima del branch" è quello del workflow stesso, non un'eccezione).
+- **`superpowers:writing-plans` non disponibile in questo ambiente**: `plan.md` è stato scritto direttamente, seguendo la stessa struttura richiesta (step numerati, convenzione commit, nessun commit automatico).
+
+## Bug trovati
+Nessun bug aggiuntivo trovato durante l'implementazione, oltre a quello oggetto del ticket.
+
+## Decisioni
+
+- **Scope esteso a `wm-core` durante l'esecuzione** (dopo l'approvazione dell'overview): il binding `[wmMapPadding]="[20, 20, 20, 20]"` su `modal-ugc-uploader.component.html`, inizialmente previsto solo come verifica temporanea da rimuovere, è stato reso **permanente** su richiesta esplicita del developer una volta confermato che il fix funziona — migliora la leggibilità della traccia caricata nel flusso di upload UGC. `overview.md` è stato aggiornato di conseguenza (Requisiti, Out of scope, Moduli toccati). Vedi anche `wm-core/docs/features/4783-controllare-il-padding-della-mappa/overview.md`.
+- Confermato (decisione utente, Fase: challenge) di **non** estendere il fix agli altri directive con lo stesso pattern (`feature-collection`, `pois`, `ugc-pois`, `hit-map`) né di gestire `wmMapDisableFitView` dentro `geojson.directive.ts` — entrambi restano fuori scope.
+- Confermato (decisione utente, Fase: challenge) di **non** aggiungere una guardia per l'interazione `wmMapGeojsonFit=true` + `wmMapPadding` grande (rischio di area utile nulla/negativa passata a OL `fit()`) — nessun consumer attuale combina i due.
+
+## Review formale (wm-review-ticket, pre-commit)
+
+Eseguita review con 5 finder paralleli su diff non ancora committato (nessuna PR esistente al momento della review). Verdetto: **APPROVATO CON RISERVE**, nessun blocker.
+
+- Confermato indipendentemente (anche rileggendo `ol/View.js:1400-1401`) che il fix risolve esattamente lo scenario del ticket, nessuna regressione per `modal-success` (altro consumer di `wmMapGeojson`).
+- Rilevato da 3 finder su 5: `await directive.mapCmp.isInit$` nel test era un no-op (`isInit$` è un `BehaviorSubject`, non una Promise) — pattern copiato da `pois.directive.spec.ts` esistente nel repo, non un errore nuovo, ma comunque corretto: rimosso. Migliorate anche le asserzioni sostituendo i controlli per-campo con `toHaveBeenCalledWith(extent, {...opzioni complete...})`, coerente con lo stile di `base.directive.spec.ts` e più robusto a regressioni sui campi `maxZoom`/`duration`/`size`.
+- Follow-up aggiuntivi emersi dalla review (non applicati in questo ticket, vedi sezione sotto): estrarre `this.wmMapPadding ?? undefined` in un getter condiviso su `WmMapBaseDirective` invece di triplicarlo; nota di attenzione per il futuro refactor di consolidamento (`fitView()` non è un drop-in sostituto di una chiamata diretta a `fit()`, ha side-effect su `wmMapDisableFitView` e query params).
+- **Resta da fare dal developer prima del merge**: eseguire realmente `geojson.directive.spec.ts` in locale (`nvm use 22 && npx ng test map-core --include='**/geojson.directive.spec.ts'`) — né io né il finder della review siamo riusciti a farlo girare in sandbox (stesso limite Chrome/GPU già documentato).
+
+## Follow-up
+- Estrarre `this.wmMapPadding ?? undefined` (ora triplicato tra `base.directive.ts` ×2 e `geojson.directive.ts`) in un getter condiviso su `WmMapBaseDirective`, es. `protected get resolvedPadding(): number[] | undefined`.
+- Ticket separato per consolidare i quattro punti di `fit()` in `map-core` (`base.directive.ts`, `map.component.ts`, `geojson.directive.ts`, e gli altri directive con padding hardcoded) su un'unica implementazione condivisa.
+- Ticket separato per estendere il rispetto di `wmMapPadding` agli altri directive (`feature-collection.directive.ts:152`, `pois.directive.ts:152`, `ugc-pois.directive.ts:135`, `hit-map.directive.ts:133`).
+- Valutare una guardia contro `wmMapGeojsonFit=true` + `wmMapPadding` con valori grandi (rischio area utile nulla/negativa in OL `fit()`), se in futuro un consumer combina i due.

--- a/docs/features/4783-controllare-il-padding-della-mappa/overview.md
+++ b/docs/features/4783-controllare-il-padding-della-mappa/overview.md
@@ -1,0 +1,37 @@
+> Ticket: oc:4783
+
+# Controllare il padding della mappa
+
+## Cosa cambia
+`WmMapGeojsonDirective._buildGeojson()` (`src/directives/geojson.directive.ts:80-84`) chiamerà `view.fit()` passando `padding: this.wmMapPadding ?? undefined`, così l'input `wmMapPadding` viene rispettato anche quando la mappa viene inquadrata (fit) su un layer GeoJSON — comportamento oggi assente perché la chiamata a `fit()` non passa alcun `padding` e OpenLayers ricade sul default `[0,0,0,0]`, ignorando silenziosamente il valore configurato sulla `View`.
+
+## Perché
+Bug trovato durante un test interno (nessuna segnalazione utente diretta): usando `<wm-map [wmMapOnly]="true" [wmMapPadding]="[20,20,20,20]" [wmMapGeojson]="...">`, il padding non ha alcun effetto visibile sulla mappa. La causa è che `geojson.directive.ts` chiama `this.mapCmp.map.getView().fit(extent, {...})` direttamente su OpenLayers invece di passare per gli helper `fitView()`/`fitViewFromLonLat()` di `WmMapBaseDirective` (`base.directive.ts:56-92`), che applicano correttamente `wmMapPadding` come default.
+
+## Requisiti
+- [x] **Verifica empirica preliminare**: eseguita dal developer manualmente in `modal-ugc-uploader` (non tramite repro automatizzato — vedi `notes.md` per i dettagli e il limite ambientale che ha impedito il test Karma/browser diretto). Esito: nessun salto verso il bbox di config, confermando l'assenza della race ipotizzata in Fase: challenge
+- [x] `geojson.directive.ts:80-85` passa `padding: this.wmMapPadding ?? undefined` nella chiamata `view.fit()` dentro `_buildGeojson()`
+- [x] Comportamento invariato per i chiamanti esistenti che non bindano `wmMapPadding` (`modal-success` in repo principale) — nessuna regressione visiva senza il binding
+- [x] `wmMapDisableFitView` resta non gestito da questo directive, invariato rispetto ad oggi (fuori scope)
+- [ ] Test Karma locale per `geojson.directive.ts` (`geojson.directive.spec.ts`) — **scritto ma non eseguito** (limite ambientale, vedi `notes.md`); il developer deve lanciarlo in locale prima del merge con `nvm use 22 && npx ng test map-core --include='**/geojson.directive.spec.ts'`
+- [x] Verifica visiva manuale: binding `[wmMapPadding]="[20, 20, 20, 20]"` su `modal-ugc-uploader.component.html` in locale (`ng serve`), confermato dal developer che il padding ha effetto
+- [x] ~~Rimozione del binding prima del commit~~ — **decisione aggiornata**: il binding resta permanente in `modal-ugc-uploader.component.html` (repo `wm-core`), non solo per la verifica. Migliora la leggibilità della traccia caricata rispetto ai bordi della mappa di anteprima nel flusso di upload UGC (vedi Moduli toccati)
+
+## Rischi
+- **Competizione tra fit del geojson e fit del bbox di config (rischio critico, da verificare empiricamente prima del fix)**: `_handleWmMapPaddingChange` (`map.component.ts:332-339`) rifitta `_view` su `_centerExtent` (bbox di config) ogni volta che `wmMapPadding` cambia — e un array literal nel template (come nel repro del ticket) cambia reference ad ogni change detection, quindi questo fit può ripetersi e sovrascrivere il fit sul geojson fatto da `geojson.directive.ts`. Mitigazione: verifica empirica come primo requisito, prima di considerare sufficiente il fix minimo.
+- **Test Karma non eseguibile in CI**: i test che istanziano una vera `OlMap` (come necessario per `geojson.directive.spec.ts`) crashano Chrome headless in CI (nota già presente in `map-core/CLAUDE.md`) — il test gira solo in locale con `nvm use 22 && npx ng test map-core`. Mitigazione: il test resta come regressione locale/documentazione, non blocca la pipeline (già lo stato attuale per i test directive/component in questo submodule).
+- **Pattern ricorrente non risolto**: altri directive (`feature-collection.directive.ts:152`, `pois.directive.ts:152`, `ugc-pois.directive.ts:135`, `hit-map.directive.ts:133`) hanno lo stesso problema strutturale (chiamano `fit()` direttamente ignorando o hardcodando il padding) — esplicitamente fuori scope per questo ticket (decisione utente), da tracciare come follow-up.
+- **Quarto punto di `fit()` duplicato**: il fix aggiunge logica di padding in un quarto punto (`geojson.directive.ts`) invece di consolidare su `fitView()`/`fitViewFromLonLat()` — accettato come scope minimo (decisione utente), da considerare in un futuro refactor di consolidamento.
+- **Interazione `wmMapGeojsonFit=true` + `wmMapPadding` grande**: quando `this.fit === true`, `_buildGeojson()` passa `size: [50,50]` (fittizia) a `fit()`; un padding ≥25px su un asse renderebbe l'area utile nulla o negativa, rischiando `NaN`/risoluzione assurda in OpenLayers. Nessun consumer attuale combina i due; accettato come rischio noto senza guardia difensiva (decisione utente) — da tracciare come follow-up.
+- **Rollback su submodule**: il fix vive in `map-core`, consumato via git submodule pin da `webmapp-app` — un rollback richiede revert nel submodule + bump del pointer nel repo padre; altre istanze con pin diverso non vedrebbero il rollback fino al loro prossimo bump. Nessun feature flag (ritenuto overkill per una one-liner di bugfix) — accettato (decisione utente).
+- **Verifica manuale con binding temporaneo**: richiede attenzione a rimuovere il binding di test da `modal-ugc-uploader.component.html` prima del commit per non introdurre un cambiamento di comportamento non richiesto in quel componente.
+
+## Out of scope
+- Fix agli altri directive con lo stesso pattern (`feature-collection`, `pois`, `ugc-pois`, `hit-map`)
+- Gestione di `wmMapDisableFitView` dentro `geojson.directive.ts`
+- Binding di `wmMapPadding` su `modal-success` (repo principale) — non richiesto, resta senza padding
+
+## Moduli toccati
+- `core/src/app/shared/map-core/src/directives/geojson.directive.ts` (fix, repo `map-core`)
+- `core/src/app/shared/map-core/src/directives/geojson.directive.spec.ts` (nuovo test locale, repo `map-core`)
+- `core/src/app/shared/wm-core/projects/wm-core/src/modal-ugc-uploader/modal-ugc-uploader.component.html` (binding permanente `wmMapPadding`, repo `wm-core`)

--- a/docs/features/4783-controllare-il-padding-della-mappa/plan.md
+++ b/docs/features/4783-controllare-il-padding-della-mappa/plan.md
@@ -1,0 +1,61 @@
+> Ticket: oc:4783
+
+# Piano — Controllare il padding della mappa
+
+Repo: `map-core` (submodule di `webmapp-app`, path `core/src/app/shared/map-core`).
+
+## Step 1 — Verifica empirica preliminare (manuale, nessun codice)
+
+Riprodurre in locale il bug esattamente come descritto nel ticket, prima di modificare qualsiasi file.
+
+1. `cd core && npm start` (o l'entry point di sviluppo di `map-core` se testato in isolamento — verificare quale `ng serve` espone un componente che monta `ModalUgcUploaderComponent`, altrimenti creare una pagina/route di test temporanea che monta `<wm-map [wmMapOnly]="true" [wmMapPadding]="[20, 20, 20, 20]" [wmMapGeojson]="...">` con il geojson allegato al ticket).
+2. Aprire la mappa e osservare, dopo il fit iniziale sul geojson, se la mappa "salta" verso un'altra inquadratura (bbox di config) nei fotogrammi successivi — sintomo della race con `_handleWmMapPaddingChange` (`map.component.ts:332-339`) identificata in Fase: challenge.
+3. Documentare l'esito in `notes.md` (creato in Step 5).
+
+**Decisione biforcazione:**
+- **Se NON si osserva alcun salto** (la race non si manifesta con binding statico, es. perché `_view` non esiste ancora quando il primo `ngOnChanges` scatta, o perché Angular non ricrea l'array literal in questo contesto specifico) → procedere con Step 2 così pianificato.
+- **Se si osserva il salto** → fermarsi e tornare dall'utente con l'evidenza prima di procedere: l'overview e il fix vanno rivisti (fuori dallo scope minimo concordato), non procedere autonomamente ad un fix più ampio.
+
+## Step 2 — Fix in `geojson.directive.ts`
+
+File: `core/src/app/shared/map-core/src/directives/geojson.directive.ts`
+
+In `_buildGeojson()` (righe 76-87), modificare la chiamata a `fit()` per includere `padding`, seguendo lo stesso pattern già usato in `base.directive.ts:56-61` (`fitView`) e `base.directive.ts:77-92` (`fitViewFromLonLat`):
+
+```ts
+this.mapCmp.map.getView().fit(extent, {
+  duration: 0,
+  maxZoom: 17,
+  padding: this.wmMapPadding ?? undefined,
+  size: this.fit ? sizeFitted : size,
+});
+```
+
+Nessun'altra modifica alla logica esistente (`_init`, `wmMapDisableFitView`, gestione di `this.fit`/`sizeFitted` restano invariati, come da Out of scope in overview.md).
+
+## Step 3 — Test Karma locale
+
+File nuovo: `core/src/app/shared/map-core/src/directives/geojson.directive.spec.ts`
+
+Modellare sulla struttura di `base.directive.spec.ts` (TestBed con componente host che monta `<wm-map wmMapGeojson [wmMapConf]="conf">`, injection della direttiva via `By.directive`).
+
+Casi da coprire:
+1. `_buildGeojson` chiama `view.fit()` con `padding: this.wmMapPadding` quando `wmMapPadding` è impostato (es. `[20, 20, 20, 20]`).
+2. `_buildGeojson` chiama `view.fit()` con `padding: undefined` quando `wmMapPadding` non è impostato (nessuna regressione per i chiamanti esistenti che non bindano l'input).
+3. (Regressione) `size` passato a `fit()` resta quello atteso (`sizeFitted` se `wmMapGeojsonFit=true`, altrimenti la size reale) — verifica che il fix non abbia alterato l'esistente.
+
+Eseguire in locale con `nvm use 22 && npx ng test map-core` (non gira in CI, coerente con la nota in `map-core/CLAUDE.md`).
+
+## Step 4 — Verifica visiva manuale
+
+1. Aggiungere temporaneamente `[wmMapPadding]="[20, 20, 20, 20]"` a `core/src/app/shared/wm-core/projects/wm-core/src/modal-ugc-uploader/modal-ugc-uploader.component.html:25-29` (rispettando la convenzione di ordine attributi in `map-core/CLAUDE.md`: `wmMapPadding` va tra `wmMapConf` e `wmMapGeojson`, essendo generico e non specifico di una direttiva).
+2. `ng serve`, aprire il flusso di upload traccia UGC, confermare visivamente che il padding ha ora effetto sull'inquadratura del geojson.
+3. Rimuovere il binding temporaneo da `modal-ugc-uploader.component.html` — verificare con `git diff` che il file torni identico all'originale prima di procedere al commit.
+
+## Step 5 — Notes e commit
+
+1. Compilare `docs/features/4783-controllare-il-padding-della-mappa/notes.md` con l'esito dello Step 1 e ogni deviazione riscontrata.
+2. Attendere approvazione esplicita del developer (review-gate del workflow) prima di qualsiasi commit.
+3. Commit (eseguiti dal developer, non automaticamente):
+   - `fix(oc:4783): apply wmMapPadding to geojson directive fit()`
+   - `test(oc:4783): add karma test for geojson directive padding`

--- a/src/directives/geojson.directive.spec.ts
+++ b/src/directives/geojson.directive.spec.ts
@@ -1,0 +1,85 @@
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {CommonModule} from '@angular/common';
+import {By} from '@angular/platform-browser';
+import {mockMapConf} from 'src/const.spec';
+import {WmMapComponent, WmMapControls} from 'src/components';
+import {WmMapGeojsonDirective} from './geojson.directive';
+
+const mockFeature = {
+  type: 'Feature',
+  geometry: {
+    type: 'Point',
+    coordinates: [11.33, 43.77],
+  },
+  properties: {},
+};
+
+@Component({
+  standalone: false,
+  template: `<wm-map
+    wmMapGeojson
+    [wmMapConf]="conf"
+    [wmMapPadding]="padding"
+    [wmMapGeojson]="geojson"
+  ></wm-map>`,
+})
+class TestComponent {
+  conf = mockMapConf;
+  padding: number[] | null = null;
+  geojson: any = null;
+}
+
+describe('WmMapGeojsonDirective', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let component: TestComponent;
+  let directive: WmMapGeojsonDirective;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [WmMapGeojsonDirective, TestComponent, WmMapComponent, WmMapControls],
+      imports: [CommonModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+
+    const directiveEl = fixture.debugElement.query(By.directive(WmMapGeojsonDirective));
+    directive = directiveEl.injector.get(WmMapGeojsonDirective);
+  });
+
+  it('_buildGeojson(1): should pass wmMapPadding to view.fit() when set', () => {
+    component.padding = [20, 20, 20, 20];
+    fixture.detectChanges();
+
+    const fitSpy = spyOn(directive.mapCmp.map.getView(), 'fit').and.callThrough();
+    const size = directive.mapCmp.map.getSize();
+
+    component.geojson = mockFeature;
+    fixture.detectChanges();
+
+    expect(fitSpy).toHaveBeenCalledWith(jasmine.any(Array), {
+      duration: 0,
+      maxZoom: 17,
+      padding: [20, 20, 20, 20],
+      size,
+    });
+  });
+
+  it('_buildGeojson(2): should pass padding as undefined when wmMapPadding is not set', () => {
+    fixture.detectChanges();
+
+    const fitSpy = spyOn(directive.mapCmp.map.getView(), 'fit').and.callThrough();
+    const size = directive.mapCmp.map.getSize();
+
+    component.geojson = mockFeature;
+    fixture.detectChanges();
+
+    expect(fitSpy).toHaveBeenCalledWith(jasmine.any(Array), {
+      duration: 0,
+      maxZoom: 17,
+      padding: undefined,
+      size,
+    });
+  });
+});

--- a/src/directives/geojson.directive.ts
+++ b/src/directives/geojson.directive.ts
@@ -80,6 +80,7 @@ export class WmMapGeojsonDirective extends WmMapBaseDirective {
         this.mapCmp.map.getView().fit(extent, {
           duration: 0,
           maxZoom: 17,
+          padding: this.wmMapPadding ?? undefined,
           size: this.fit ? sizeFitted : size,
         });
         this._featureCollectionLayer.changed();


### PR DESCRIPTION
## Summary
- `WmMapGeojsonDirective._buildGeojson()` chiamava `view.fit()` senza passare `padding`, così OpenLayers ricadeva su `[0,0,0,0]` ignorando `wmMapPadding` configurato sulla `View`
- Aggiunto `padding: this.wmMapPadding ?? undefined` alla chiamata `fit()`, stesso pattern già usato in `base.directive.ts` (`fitView`/`fitViewFromLonLat`)
- Aggiunto test Karma (`geojson.directive.spec.ts`) — **da eseguire in locale prima del merge**: `nvm use 22 && npx ng test map-core --include='**/geojson.directive.spec.ts'` (l'ambiente CI/sandbox non riesce ad avviare Chrome per i test che istanziano una vera OlMap, vedi `map-core/CLAUDE.md`)
- Documentazione completa in `docs/features/4783-controllare-il-padding-della-mappa/`

## Test plan
- [ ] Eseguire `nvm use 22 && npx ng test map-core --include='**/geojson.directive.spec.ts'` in locale e verificare che passi
- [x] Verificato manualmente in `modal-ugc-uploader` (repo `wm-core`, PR collegata): il padding ora ha effetto visibile sulla traccia caricata

Ticket: oc:4783

🤖 Generated with [Claude Code](https://claude.com/claude-code)