### PR TITLE
fix(oc:8219): fallback locale offline per confini fogli CARG e icone controlli mappa

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,21 @@
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Fallback offline per fogli CARG e icone controlli mappa | oc:8219 | `src/directives/hit-map.directive.ts`, `src/components/controls/button/button.controls.map.ts`, `src/utils/localForage.ts`, `src/utils/cacheFallback.ts` | Cache locale dedicata con fallback quando il fetch remoto fallisce offline; `withCacheFallback` condiviso tra i due; `distinctUntilChanged` evita il re-fetch delle icone ad ogni riconnessione di rete |
 | Filtro POI type esteso ai related POI | oc:7646 | `src/directives/track.related-pois.directive.ts`, `src/directives/pois.directive.ts`, `src/utils/ol.ts` | wmMapPoisFilters ora filtra anche i POI della traccia corrente; fallback su taxonomy.poi_type.identifier se taxonomyIdentifiers assente |
 | EC POI: show_image_on_map | oc:7988 | `src/directives/track.related-pois.directive.ts`, `src/types/model.ts` | Rendering POI su mappa pilotato dal campo `feature_image.show_image_on_map`; fallback legacy per app mobile |
 
 ## Decisioni architetturali
+
+### Fallback offline per fogli CARG e icone controlli mappa (oc:8219)
+- **Solo cache locale, nessun retry su riconnessione**: per scaricare un foglio l'utente deve prima cliccarlo sulla mappa, il che richiede che il layer di hit-test sia già stato costruito con successo — quindi un fetch riuscito (e una cache valida) esiste sempre prima che un download possa esistere. Il fallback da cache copre interamente lo scenario "riapro l'app offline dopo un download", senza bisogno di ascoltare lo stato di rete.
+- **Cache dedicate, non riuso di `saveFeatureCollection`/`getFeatureCollection`**: quelle funzioni condividono keyspace con i download per-foglio di `downloadOverlay()` e hanno un fallback di rete implicito su cache-miss — avrebbero reintrodotto un retry non voluto. Nuove istanze `localForage`: `hitMapBoundariesLocalForage`, `iconBlobsLocalForage`.
+- **Icone dei controlli mappa non passano da `<wm-img>`/`getImg` (wm-core)**: `map-core` non dipende mai da `wm-core` (libreria OL indipendente); inoltre `getImg()` legge da cache popolate solo dal flusso di sync UGC/foto profilo, non dalle icone di config. Nuova cache locale autonoma in `map-core`.
+- **`withCacheFallback` (`src/utils/cacheFallback.ts`)**: operatore RxJS condiviso per il pattern fetch→valida→salva→fallback, usato sia da `hit-map.directive.ts` sia da `button.controls.map.ts` — evita di duplicare la stessa catena switchMap/catchError con validazioni divergenti (una review pre-commit aveva trovato l'icona cachata senza validazione, a differenza della GeoJSON).
+- **`distinctUntilChanged()` obbligatorio su pipeline innescate da un `@Input` setter ricostruito da NgRx**: `conf.reducer.ts` crea nuovi riferimenti oggetto per i control `tiles`/`data`/`overlays` ad ogni `loadConfSuccess`, e l'app dispatcha `loadConf()` ad ogni riconnessione di rete (`home.page.ts`) — senza `distinctUntilChanged`, ogni reconnect rifaceva il fetch di tutte le icone anche se invariate.
+- **Guardia su componente distrutto durante un cache-lookup asincrono pendente**: nessuna directive/componente di questo file ha `ngOnDestroy`/`takeUntil` per disiscrivere subscription pendenti; `WmMapComponent.ngOnDestroy()` imposta `this.map = null` — qualsiasi callback che dereferenzia `this.mapCmp.map` dopo un hop asincrono (es. lettura da `localForage`) deve controllare `!= null` prima di usarlo.
+- **`button.controls.map.spec.ts` in CI headless**: è presentazionale (nessun `OlMap`), aggiunto a `angular.json` → `configurations.ci.include` — a differenza degli altri directive/component spec che montano un vero `OlMap` e restano esclusi dalla CI (limite GPU, vedi "Note ambiente").
+- **Debito noto non affrontato**: fix di `CustomTileSource` per l'inaffidabilità di `navigator.onLine` sui tile raster (problema preesistente, più ampio di questo ticket); rimozione di `loadHitmap$`/`loadHitmapFeatures`/`wmMapHitmapFeatures` in wm-core (codice apparentemente morto, proposto come ticket Task separato).
 
 ### Filtro POI type ai related POI (oc:7646)
 - `_allPoiMarkers` (superset) è separato da `_poiMarkers` (stato corrente del layer): i marker vengono creati una sola volta e filtrati al volo senza ricrearli.

--- a/angular.json
+++ b/angular.json
@@ -44,7 +44,8 @@
                 "src/utils/popover.spec.ts",
                 "src/utils/httpRequest.spec.ts",
                 "src/utils/img.spec.ts",
-                "src/utils/performance.spec.ts"
+                "src/utils/performance.spec.ts",
+                "src/components/controls/button/button.controls.map.spec.ts"
               ]
             }
           }

--- a/docs/features/8219-fogli-carg-offline-dopo-riapertura-app/notes.md
+++ b/docs/features/8219-fogli-carg-offline-dopo-riapertura-app/notes.md
@@ -1,0 +1,45 @@
+> Ticket: oc:8219
+
+# Notes — Fogli raster CARG non si caricano se l'app viene riaperta offline dopo il download
+
+## Deviazioni dal piano
+
+- **Retry su riconnessione rimosso dallo scope** prima dell'implementazione: l'overview iniziale prevedeva anche un `@Input() wmMapHitMapOnline` con wiring in `wm-core` (`geobox-map.component.ts`). Rianalizzando lo scenario, il solo fallback da cache locale copre interamente il bug (un fetch riuscito, e quindi una cache valida, esiste sempre prima che un download possa esistere) — eliminata la parte di retry/wiring wm-core prima di scrivere codice, nessuna modifica a wm-core in questo ciclo.
+- **Estensione di scope in corsa**: durante la verifica manuale della fix principale, è emerso che anche le icone dei controlli mappa (`WmMapButtonControls`, `icon_url`) restano vuote offline — stesso sintomo di fondo (risorsa remota senza fallback), meccanismo e componente diversi, non CARG-specifico. Incluso in questo ciclo su richiesta esplicita del developer invece di aprire un ticket separato. `overview.md` e `plan.md` sono stati aggiornati per riflettere l'estensione (sezioni "Requisiti aggiuntivi — icone dei controlli mappa" e Step 1B/2B/3B).
+- **`_renderHitMap()` con try/catch dentro la callback `precompose`**, non attorno a `map.once(...)`: l'eccezione di `_buildGeojson()`/`_addTileLayer()` si verifica dentro la callback asincrona, non nella chiamata sincrona a `map.once`.
+
+## Bug trovati
+
+- Spiare direttamente le funzioni esportate da `localForage.ts` (`saveHitMapBoundaries`, `getHitMapBoundariesFromCache`, `saveIconBlob`, `getIconBlobFromCache`) con `spyOn(moduleNamespace, 'fnName')` fallisce a runtime con `<spyOn> : ... is not declared writable or has no setter` — le esportazioni ES module compilate da questo build (webpack/TS) non sono configurabili. Fix: spiare i metodi dell'istanza `localForage` sottostante (es. `hitMapBoundariesLocalForage.setItem`/`getItem`, `iconBlobsLocalForage.setItem`/`getItem`), che sono proprietà di un oggetto plain JS e restano spiabili normalmente. **Da tenere a mente per futuri test che spiano funzioni esportate da modulo in questo repo** — non è un problema specifico di questo ticket, riguarda qualunque test futuro con lo stesso pattern.
+- `hit-map.directive.spec.ts` falliva con `NG0201: No provider found for ActivatedRoute` — `WmMapComponent` (map-core) inietta `ActivatedRoute` nel costruttore; nessuno spec esistente nel repo lo fornisce esplicitamente nel `TestBed`. Aggiunto un provider stub minimo. Probabile problema latente anche per gli altri spec esistenti che montano `WmMapComponent` — non indagato oltre, fuori scope.
+
+## Decisioni
+
+- Cache dedicata (`hitMapBoundariesLocalForage`, `iconBlobsLocalForage`) invece di riuso di `saveFeatureCollection`/`getFeatureCollection` esistenti — vedi "Rischi" in `overview.md` (keyspace condiviso con i download per-foglio + fallback di rete implicito indesiderato).
+- Icone dei controlli mappa: nuova cache locale in `map-core` invece di riuso di `<wm-img>`/`getImg` (wm-core) — `<wm-img>` dipende da `@wm-core/utils/localForage`, userlo da `map-core` violerebbe il confine architetturale "map-core non dipende da wm-core" già scelto per il retry della GeoJSON. Inoltre `getImg()` legge da cache (`deviceImg`/`synchronizedImg`) popolate solo dal flusso di sync UGC/foto profilo — le icone di config CARG non ci finirebbero comunque dentro senza ulteriore lavoro su wm-core.
+
+## Review formale (wm-review-ticket, pre-commit)
+
+Eseguita una review con 5 finder paralleli sul diff non ancora committato. Verdetto: approvato con riserve, 2 blocker + 5 cleanup, tutti corretti prima del commit.
+
+**Blocker corretti:**
+- **Crash null-pointer su distruzione componente durante un cache-lookup pendente** (`hit-map.directive.ts`, `_renderHitMap`): se il fetch fallisce offline e l'utente naviga via prima che `getHitMapBoundariesFromCache()` si risolva, `WmMapComponent.ngOnDestroy()` ha già impostato `this.mapCmp.map = null` — la vecchia `_renderHitMap` chiamava `.once()` su `null` fuori dal try/catch. Aggiunta una guardia `if (this.mapCmp.map == null) return;` in testa al metodo. Nuovo test dedicato: "componente distrutto durante il cache-lookup pendente".
+- **Icone dei controlli mappa ri-scaricate ad ogni riconnessione di rete** (`button.controls.map.ts`): `conf.reducer.ts` crea nuovi riferimenti oggetto per ogni control ad ogni `loadConfSuccess`, e `home.page.ts` dispatcha `loadConf()` ad ogni transizione offline→online — senza `distinctUntilChanged()`, ogni riconnessione rifaceva il fetch di tutte le icone. Aggiunto `distinctUntilChanged()` sulla pipeline `iconSrc$`.
+
+**Cleanup corretti:**
+- Validazione minima del blob delle icone prima di cachare (`isValidIconBlob`, rifiuta blob vuoti) — simmetrico alla validazione già presente per la GeoJSON.
+- Estratto un operatore RxJS condiviso `withCacheFallback` (nuovo file `src/utils/cacheFallback.ts`) che unifica il pattern "fetch → valida → salva su successo → fallback da cache su fallimento/payload invalido", usato sia da `hit-map.directive.ts` sia da `button.controls.map.ts` — elimina la duplicazione segnalata dalla review e logga l'errore HTTP originale prima di ricadere sulla cache (prima veniva scartato silenziosamente).
+- `isValidFeatureCollection` ora esportata e riusata anche sul ramo di successo (non solo prima della scrittura in cache): un payload 200 ma con schema errato ora fa fallback sulla cache invece di tentare un render con dati corrotti.
+- Rinominato `_iconUrlEVT$` → `_iconUrl$` (il suffisso `EVT$` nel repo è riservato a `@Output`/eventi, non a stato interno).
+- Riscritto il test "fetch riuscito con payload non valido": la versione precedente chiamava le funzioni di `localForage.ts` direttamente, bypassando la pipeline della direttiva — ora esercita `directive.wmMapHitMapUrl` con un payload invalido e verifica sia il mancato overwrite della cache sia il fallback effettivo.
+- Aggiunto assert mancante nel test "cache con payload corrotto" (`_addTileLayer` non deve essere chiamato).
+- Decisione presa sull'inclusione CI (richiesta da `plan.md` Step 3B, mai presa prima): `button.controls.map.spec.ts` aggiunto a `angular.json` → `configurations.ci.include` — è presentazionale, nessun `OlMap`/GPU richiesto. Verificato: `CI=true npx ng test map-core --configuration=ci` → 31/31 SUCCESS (27 preesistenti + 4 nuovi).
+
+Dopo i fix, `nvm use 22 && npx ng test map-core` (locale, GPU) resta comunque necessario per verificare i 6 test di `hit-map.directive.spec.ts` (non eseguibili in modo affidabile in questo sandbox, vedi sopra).
+
+## Follow-up
+
+- **Ticket Task separato proposto**: rimozione di `loadHitmap$` / `loadHitmapFeatures` / `wmMapHitmapFeatures` (`user-activity.effects.ts`, wm-core) — meccanismo di fetch equivalente a quello fixato in questo ticket ma apparentemente senza consumer (nessun componente sottoscrive lo state risultante), scoperto durante l'analisi ma esplicitamente out of scope qui.
+- **Verifica manuale richiesta al developer prima del merge**: eseguire `nvm use 22 && npx ng test map-core` in locale per una verifica affidabile di `hit-map.directive.spec.ts` (in questo sandbox l'esecuzione reale di test che montano un vero `OlMap` non è affidabile — anche spec preesistenti e non toccati da questa fix, es. `pois.directive.spec.ts`, falliscono qui per un problema di bootstrap globale scollegato da questo ticket). `button.controls.map.spec.ts` è stato invece verificato con successo in questo sandbox (4/4 test passano).
+- **Test manuale su device/emulatore Android in modalità aereo**: non eseguito in questa sessione (nessun device disponibile) — demandato al developer prima del merge, come da `overview.md`.
+- **CORS sulle icone `icon_url`**: non verificato se i CDN attualmente usati per le icone dei controlli mappa espongono header CORS — se non li espongono, il fetch blob fallirà sempre (fallback sicuro sull'URL diretto, nessuna regressione) ma con una richiesta di rete aggiuntiva ad ogni icona. Da monitorare dopo il rilascio.

--- a/docs/features/8219-fogli-carg-offline-dopo-riapertura-app/overview.md
+++ b/docs/features/8219-fogli-carg-offline-dopo-riapertura-app/overview.md
@@ -1,0 +1,77 @@
+> Ticket: oc:8219
+
+# Fogli raster CARG non si caricano se l'app viene riaperta offline dopo il download
+
+## Cosa cambia
+
+`WmMapHitMapDirective` (`hit-map.directive.ts`) smette di dipendere in modo esclusivo da un fetch remoto one-shot per costruire il layer di hit-test dei fogli CARG (`_hitMapLayer`):
+
+- Ogni fetch remoto riuscito della GeoJSON dei confini fogli (`wmMapHitMapUrl`) viene persistito in `localForage` (map-core, `localForage.ts`).
+- Se il fetch remoto fallisce (es. app avviata offline), la direttiva ricostruisce `_hitMapLayer` a partire dalla GeoJSON in cache locale, se presente — il click su un foglio già scaricato in precedenza torna a funzionare offline.
+
+Nessun meccanismo di retry sulla riconnessione: per poter scaricare un foglio, l'utente deve prima averlo cliccato sulla mappa, il che richiede che `_hitMapLayer` sia già stato costruito con successo — quindi un fetch remoto riuscito (e di conseguenza una cache valida) esiste sempre prima che un download possa esistere. Il solo fallback da cache locale copre quindi interamente lo scenario del ticket, senza bisogno di ascoltare lo stato di rete né di introdurre dipendenze tra `map-core` e `wm-core`.
+
+**Estensione dello scope (scoperta durante l'implementazione):** anche le icone dei controlli mappa (pannello "features"/layer switcher: `tiles`/`data`/`overlays` di `ICONTROLS`) risultano vuote offline. `WmMapButtonControls` (`components/controls/button/button.controls.map.ts`) renderizza `control.icon_url` con un semplice `<img [src]="iconUrl">` su un URL remoto, senza alcuna cache — a differenza del layer di hit-test, qui non esiste nessun meccanismo offline preesistente. Si applica lo stesso pattern già validato per la GeoJSON dei confini: fetch dell'icona come blob, cache locale dedicata al successo, fallback dalla cache al fallimento.
+
+A differenza del resto della fix (scoperta esplicitamente per `hitMapUrl`/CARG), questa parte **non è CARG-specific**: `ICONTROLSBUTTON.icon_url` è un campo generico usato da tutti gli shard che configurano icone remote per i controlli `tiles`/`data`/`overlays` — il fix si applica a tutte le app, non solo a CARG.
+
+## Perché
+
+Bug segnalato su build Android shard CARG: dopo aver scaricato un foglio raster online, chiudendo e riaprendo l'app offline il foglio risulta nell'elenco download ma il click sulla mappa non fa nulla. Root cause: `_http.get(url)` nel setter di `wmMapHitMapUrl` non ha `catchError`/fallback — se fallisce, `_hitMapLayer` non viene mai creato in quella sessione, anche se i tile del foglio sono già disponibili offline in `localForage` (serviti da `CustomTileSource`). Il secondo sintomo riportato ("tornando online senza riavviare l'app la mappa resta bloccata") è conseguenza diretta dell'assenza totale di fallback: con la cache locale in place non si presenta più, perché l'app offline funziona già correttamente fin da subito.
+
+Durante la verifica manuale della fix, l'utente ha notato che anche le icone del pannello dei controlli mappa (es. "Geologia punti/linee/poligoni") restano vuote offline — stesso sintomo di fondo (risorsa remota senza fallback locale), componente e meccanismo diversi. Incluso in questo ciclo su richiesta esplicita, invece di aprire un ticket separato.
+
+## Requisiti
+
+- [ ] La GeoJSON dei confini fogli (`wmMapHitMapUrl`) viene salvata in cache locale dedicata ad ogni fetch remoto riuscito, **solo dopo validazione minima dello schema** (es. `type === 'FeatureCollection'`) — un payload non valido (es. pagina HTML di manutenzione risposta con 200) non deve mai sovrascrivere una cache precedente valida
+- [ ] Se il fetch fallisce, `_hitMapLayer` viene costruito dalla GeoJSON in cache locale, se presente
+- [ ] Il branch di fallback-da-cache chiama sia `_buildGeojson()` sia `_addTileLayer()`, a specchio del branch di successo (righe 37-42 attuali) — senza questo il layer raster CARG non verrebbe mai creato pur avendo il layer di hit-test funzionante
+- [ ] `_buildGeojson()` è avvolta in try/catch in entrambi i branch (successo e fallback): un payload corrotto logga l'errore e lascia lo stato invariato (nessun layer), non propaga l'eccezione fuori dalla subscribe RxJS
+- [ ] Cache dedicata su istanza `localForage` separata da quella usata da `downloadOverlay()` per le feature-collection per-foglio (nuove funzioni, es. `saveHitMapBoundaries(url, geojson)` / `getHitMapBoundariesFromCache(url)`, su una nuova istanza tipo `hitMapBoundariesLocalForage`) — nessun riuso di `saveFeatureCollection`/`getFeatureCollection` esistenti, che condividono keyspace con i download per-foglio e hanno un fallback di rete implicito su cache-miss che reintrodurrebbe un retry non voluto
+- [ ] Se non c'è né fetch riuscito né cache locale disponibile, il comportamento resta quello attuale (nessun layer, nessun errore non gestito)
+- [ ] Fix scoperta esplicitamente per l'uso attuale di `hitMapUrl` (solo shard CARG) — nessuna astrazione generica pensata per altri shard
+- [ ] Unit test Karma su `hit-map.directive.ts`: mock `HttpClient` che fallisce + verifica fallback da cache locale (inclusa chiamata a `_addTileLayer()`); mock fetch riuscito + verifica che la GeoJSON venga salvata in cache dedicata; mock payload non valido (schema errato) + verifica che la cache precedente non venga sovrascritta; mock cache corrotta + verifica che l'eccezione non si propaghi
+
+### Requisiti aggiuntivi — icone dei controlli mappa
+
+- [ ] `WmMapButtonControls` risolve `control.icon_url` come blob via `HttpClient` invece del binding diretto `<img [src]="iconUrl">`
+- [ ] Ogni fetch riuscito salva il blob dell'icona in una cache locale dedicata (nuova istanza `localForage`, es. `iconBlobsLocalForage`, separata da `hitMapBoundariesLocalForage` e da `featureCollectionLocalForage`)
+- [ ] Se il fetch fallisce, l'icona viene letta dalla cache locale se presente e mostrata da lì (object URL dal blob cachato)
+- [ ] Se non c'è né fetch riuscito né cache disponibile, fallback sul comportamento attuale (binding diretto all'URL remoto) — nessuna regressione visibile rispetto a oggi in quel caso
+- [ ] Gli object URL creati con `URL.createObjectURL` vengono revocati (`URL.revokeObjectURL`) quando non più necessari (cambio icona, distruzione componente) per evitare leak di memoria
+- [ ] Il fallback `control.icon` (SVG inline sanitizzato, ramo `else sanitazeIcon` del template) resta invariato — non necessita fix, il dato è già embedded nella config e disponibile offline
+- [ ] Fix applicata a tutti gli usi di `icon_url` in `ICONTROLSBUTTON` (tiles/data/overlays), non solo al contesto CARG — coerente con la natura generica del componente
+- [ ] Unit test Karma su `button.controls.map.ts`: mock `HttpClient` che fallisce + verifica fallback da cache; mock fetch riuscito + verifica che il blob venga salvato in cache; mock fetch fallito e cache assente + verifica fallback sull'URL diretto
+
+## Rischi
+
+- **Tile raster non coperti dal fix — limite noto, accettato**: `CustomTileSource` (`map-core/src/utils/ol.ts`) decide se servire un tile dalla cache o dalla rete guardando `navigator.onLine`, non l'esito reale della richiesta HTTP. `navigator.onLine` è inaffidabile in WebView (es. Wi-Fi connesso senza internet reale, captive portal — scenario plausibile in aree outdoor). In quel caso il layer di hit-test si ricostruisce correttamente da cache (click funzionante) ma i tile raster potrebbero comunque apparire rotti/vuoti. Fuori scope: problema preesistente di `CustomTileSource`, non introdotto da questo fix — non toccato in questo ciclo.
+- **Cache stale**: la GeoJSON cachata potrebbe non riflettere modifiche ai confini fogli lato backend se l'utente resta a lungo offline. Accettato per questo ciclo: il fallback è pensato per lo scenario "riapro l'app offline dopo un download recente", non come sostituto permanente del dato remoto — al primo fetch riuscito e validato la cache viene sovrascritta.
+- **Cache mai popolata**: se l'app non ha mai fatto un fetch riuscito in precedenza (nessun dato in cache), il layer resta assente come oggi — accettabile perché in quel caso non può comunque esistere nessun foglio scaricato da mostrare.
+- **Affidabilità di `localForage` su iOS**: WKWebView può evictare in modo aggressivo IndexedDB/localStorage sotto pressione di storage o dopo lunga inattività dell'app — il fallback potrebbe smettere di funzionare in modo intermittente e difficile da riprodurre. Limite noto della piattaforma, non mitigabile in questo ticket.
+- **Invariante implicito "click sulla mappa prima del download" non imposto da test/architettura**: il fix assume che un fetch riuscito (e quindi una cache valida) esista sempre prima che un download possa esistere, perché oggi l'unico modo di avviare un download passa dal click su `_hitMapLayer`. Se una feature futura introducesse un percorso di download alternativo (es. "ri-scarica dalla lista download" senza passare dal click mappa), questa assunzione si romperebbe silenziosamente e il bug potrebbe ripresentarsi in forma nuova. Da tenere presente in review future, non azionabile ora.
+- **Nessun timeout esplicito sul fetch remoto**: su reti lente-ma-non-morte il fallback scatterebbe solo dopo un'attesa lunga, con UX peggiore di un fallimento immediato. Micro-miglioramento non richiesto da questo ticket.
+- **Nessun feature flag/kill switch, rollback lento**: `map-core` è un submodulo git con versione pinnata via commit SHA — un regresso introdotto da questo fix richiederebbe bump submodulo + nuova build + nuova release app store per essere disattivato, non un lever lato backend. Intrinseco all'architettura del progetto, non specifico di questa fix.
+- **Cache senza versionamento/TTL, storage quota-exceeded silenzioso**: `saveFeatureCollection`-style functions loggano solo `console.error` su fallimento di scrittura, senza segnale visibile all'utente o telemetria. Debito tecnico accettato per lo scope di questo bug fix.
+- **Blast radius più ampio per il fix delle icone**: `WmMapButtonControls` è un componente generico usato da tutti gli shard per tiles/data/overlays, non solo CARG — un regresso qui (es. leak di object URL, icone che smettono di aggiornarsi se il backend cambia l'immagine) si propaga a tutte le app, non solo a quella coinvolta nel bug originale. Mitigato dal fallback esplicito sul comportamento attuale in caso di fetch e cache entrambi falliti (nessuna regressione visibile in quel caso).
+- **CORS su fetch via `HttpClient` per le icone**: un `<img src>` diretto non richiede header CORS per essere visualizzato (richiesta opaca), mentre `HttpClient.get(url, {responseType: 'blob'})` sì. Se il CDN delle icone non espone `Access-Control-Allow-Origin`, il fetch blob fallisce anche online — il fallback ricade sul binding diretto all'URL (stesso comportamento di oggi, quindi nessuna regressione), ma comporta un doppio tentativo di rete (fetch blob fallito + `<img>` diretto) per ogni icona dietro un CDN senza CORS, con latenza aggiuntiva. Da verificare quali CDN sono effettivamente usati per `icon_url` nelle config esistenti.
+- **Cache icone senza versionamento**: se il backend sostituisce l'immagine dietro lo stesso `icon_url` (stesso problema di staleness già accettato per la GeoJSON), l'icona cachata offline potrebbe non riflettere l'ultima versione — accettato per lo stesso motivo (fallback pensato per uso recente offline, non sostituto permanente del dato remoto).
+
+## Out of scope
+
+- Fix di `CustomTileSource`/gestione `navigator.onLine` per i tile raster — vedi Rischi, problema preesistente e più ampio di questo ticket.
+- Retry automatico del fetch alla riconnessione di rete — non necessario per lo scenario del ticket (vedi "Cosa cambia"); eventuale nice-to-have per l'edge case di cache mai popolata, da valutare separatamente se mai richiesto.
+- Rimozione di `loadHitmap$` / `loadHitmapFeatures` / `wmMapHitmapFeatures` (action/effect/reducer/selector in `user-activity.effects.ts`, wm-core) — meccanismo di fetch equivalente ma apparentemente senza consumer (nessun componente lo sottoscrive), non collegato a questo bug. Segnalato come follow-up in `notes.md`, da trattare come ticket Task separato.
+- Generalizzazione di `hitMapUrl`/`overlayXYZ` per shard diversi da CARG.
+- Modifiche a `wm-core` (nessuna necessaria: la fix è interamente contenuta in `map-core`).
+- Riuso del meccanismo `getImg`/`OfflineCallbackManager` già esistente in `wm-core` per le immagini UGC/profilo — non applicabile senza violare il confine `map-core`↛`wm-core`, e concettualmente diverso (quel meccanismo presuppone un passo di sync/download esplicito, assente per le icone di config)
+- Test E2E Cypress per lo scenario "chiudi/riapri app offline dopo download" — non riproducibile in modo affidabile con gli intercept Cypress attuali (richiede controllo reale di rete + persistenza `localForage` tra reload app). Verifica manuale su device/emulatore Android in modalità aereo demandata al developer post-merge.
+- Fix di eventuali altri usi di `<img src>` remoti non coperti da questo ticket (es. altre parti dell'app che mostrano immagini di config) — limitato esplicitamente a `WmMapButtonControls`/`icon_url` scoperto in questo ciclo.
+
+## Moduli toccati
+
+- `map-core/src/directives/hit-map.directive.ts` — fallback da cache locale sul fetch fallito, validazione schema anche sul ramo di successo, guardia su componente distrutto, try/catch su `_buildGeojson()`
+- `map-core/src/utils/localForage.ts` — nuove funzioni dedicate di persistenza/lettura della GeoJSON dei confini fogli e dei blob delle icone (con validazione), su istanze `localForage` separate
+- `map-core/src/utils/cacheFallback.ts` (nuovo) — operatore RxJS condiviso `withCacheFallback`, usato sia da `hit-map.directive.ts` sia da `button.controls.map.ts`
+- `map-core/src/components/controls/button/button.controls.map.ts` — risoluzione di `icon_url` come blob con cache locale, fallback, e `distinctUntilChanged()` per evitare re-fetch ad ogni riconnessione
+- `map-core/angular.json` — `button.controls.map.spec.ts` aggiunto all'`include` CI headless

--- a/docs/features/8219-fogli-carg-offline-dopo-riapertura-app/plan.md
+++ b/docs/features/8219-fogli-carg-offline-dopo-riapertura-app/plan.md
@@ -1,0 +1,215 @@
+> Ticket: oc:8219
+
+# Piano implementativo — Fogli raster CARG non si caricano se l'app viene riaperta offline dopo il download
+
+Repo: `map-core` (submodulo). Nessuna modifica a `wm-core` o al repo principale (vedi `overview.md`).
+
+Commit convention: `feat(oc:8219): ...` / `fix(oc:8219): ...` / `test(oc:8219): ...`.
+
+⚠️ I commit indicati sotto ogni step sono istruzioni testuali per il developer, non azioni automatiche — nessun commit va eseguito senza conferma esplicita dell'utente (Fase: execution → review-gate).
+
+---
+
+## Step 1 — Cache dedicata in `localForage.ts`
+
+File: `map-core/src/utils/localForage.ts`
+
+- Aggiungere una nuova istanza localForage dedicata, separata da `featureCollectionLocalForage`:
+  ```ts
+  export const hitMapBoundariesLocalForage = localforage.createInstance({
+    name: 'map-core',
+    storeName: 'hitmapBoundaries',
+  });
+  ```
+- Aggiungere una funzione di validazione minima dello schema:
+  ```ts
+  function isValidFeatureCollection(payload: any): payload is WmFeatureCollection {
+    return payload != null && payload.type === 'FeatureCollection' && Array.isArray(payload.features);
+  }
+  ```
+- Aggiungere `saveHitMapBoundaries(url: string, geojson: WmFeatureCollection): Promise<void>`:
+  - Se `!isValidFeatureCollection(geojson)`, non scrivere nulla (log `console.error`) — non deve mai sovrascrivere una cache precedente valida con un payload rotto.
+  - Altrimenti `await hitMapBoundariesLocalForage.setItem(url, geojson)`, try/catch con `console.error` (stesso pattern delle altre funzioni del file).
+- Aggiungere `getHitMapBoundariesFromCache(url: string): Promise<WmFeatureCollection | null>`:
+  - `await hitMapBoundariesLocalForage.getItem<WmFeatureCollection>(url)`, try/catch con `console.error`, ritorna `null` su errore o cache-miss.
+  - **Nessun fallback di rete interno** (a differenza di `getFeatureCollection` esistente) — la responsabilità del fetch resta nella directive.
+- Aggiungere `hitMapBoundariesLocalForage.clear()` a `clearMapCoreData()`, per coerenza con le altre istanze già pulite lì.
+
+Non toccare `saveFeatureCollection`/`getFeatureCollection` esistenti (restano dedicate al flusso `downloadOverlay()` per-foglio).
+
+**Verifica step:** `npx tsc --noEmit` (o build map-core) passa senza errori di tipo.
+
+---
+
+## Step 1B — Cache blob icone in `localForage.ts` (estensione scope)
+
+Stesso file dello Step 1, stesso pattern.
+
+- Nuova istanza dedicata, separata sia da `hitMapBoundariesLocalForage` sia da `featureCollectionLocalForage`:
+  ```ts
+  export const iconBlobsLocalForage = localforage.createInstance({
+    name: 'map-core',
+    storeName: 'iconBlobs',
+  });
+  ```
+- `saveIconBlob(url: string, blob: Blob): Promise<void>` — `await iconBlobsLocalForage.setItem(url, blob)`, try/catch con `console.error`. Nessuna validazione di schema necessaria (un `Blob` valido arriva già come tale da `HttpClient` con `responseType: 'blob'`; una risposta HTTP non-2xx finisce nel branch di errore, non qui).
+- `getIconBlobFromCache(url: string): Promise<Blob | null>` — `await iconBlobsLocalForage.getItem<Blob>(url)`, try/catch, ritorna `null` su errore o cache-miss. Nessun fallback di rete interno (stessa filosofia di `getHitMapBoundariesFromCache`).
+- Aggiungere `iconBlobsLocalForage.clear()` a `clearMapCoreData()`.
+
+**Verifica step:** `npx tsc --noEmit` passa senza errori di tipo.
+
+---
+
+## Step 2 — Fallback e validazione in `hit-map.directive.ts`
+
+File: `map-core/src/directives/hit-map.directive.ts`
+
+1. Importare `saveHitMapBoundaries`, `getHitMapBoundariesFromCache` da `@map-core/utils` (via `localForage.ts`, seguendo il barrel export esistente per `localForage.ts` se presente, altrimenti path diretto coerente con l'import già presente di `CustomTileSource`/`coordsFromLonLat` da `@map-core/utils`).
+
+2. Estrarre la logica di rendering in un metodo privato condiviso tra branch di successo e di fallback:
+   ```ts
+   private _renderHitMap(geojson: WmFeatureCollection): void {
+     try {
+       this.mapCmp.map.once('precompose', () => {
+         this._buildGeojson(geojson);
+         this._addTileLayer();
+       });
+     } catch (e) {
+       console.error('Failed to render hit map from geojson', e);
+     }
+   }
+   ```
+   (il try/catch copre l'eccezione sincrona di `_buildGeojson`/`_addTileLayer` se lanciata prima della callback `once`; se l'eccezione può verificarsi dentro la callback `precompose` stessa — asincrona rispetto al chiamante — spostare il try/catch dentro la callback, non attorno a `map.once(...)`. Verificare a implementazione quale dei due casi si applica leggendo dove effettivamente viene lanciata l'eccezione di OpenLayers/GeoJSON parsing.)
+
+3. Riscrivere il setter `wmMapHitMapUrl`:
+   ```ts
+   @Input() set wmMapHitMapUrl(url: undefined | string) {
+     this.mapCmp.isInit$
+       .pipe(
+         filter(e => e === true && url != null),
+         switchMap(_ =>
+           this._http.get(url).pipe(
+             tap((geojson: WmFeatureCollection) => saveHitMapBoundaries(url, geojson)),
+             catchError(_ => from(getHitMapBoundariesFromCache(url))),
+           ),
+         ),
+         filter(geojson => geojson != null),
+         take(1),
+       )
+       .subscribe((geojson: WmFeatureCollection) => {
+         this._renderHitMap(geojson);
+       });
+   }
+   ```
+   - Import aggiuntivi da `rxjs/operators`: `catchError`, `tap`; da `rxjs`: `from`.
+   - Se sia il fetch che la cache falliscono (`getHitMapBoundariesFromCache` risolve `null`), il `filter(geojson => geojson != null)` scarta l'emissione — nessun layer, nessun errore, comportamento invariato rispetto ad oggi (requisito esplicito dell'overview).
+   - `saveHitMapBoundaries` internamente valida lo schema prima di scrivere (Step 1) — nessuna validazione duplicata qui nella directive.
+
+**Verifica step:** lettura del diff — confermare che il branch di successo continua a chiamare `_buildGeojson` + `_addTileLayer` esattamente come oggi (via `_renderHitMap`), e che il branch di fallback fa lo stesso.
+
+---
+
+## Step 2B — Fallback e cache in `button.controls.map.ts` (estensione scope)
+
+File: `map-core/src/components/controls/button/button.controls.map.ts` (+ template inline nello stesso file)
+
+1. Iniettare `HttpClient` nel costruttore, importare `saveIconBlob`/`getIconBlobFromCache` da `@map-core/utils`, implementare `OnDestroy`.
+
+2. Sostituire il binding diretto con un observable risolto:
+   ```ts
+   private _iconUrlEVT$ = new BehaviorSubject<string | null>(null);
+   private _lastObjectUrl: string | null = null;
+
+   iconSrc$: Observable<string> = this._iconUrlEVT$.pipe(
+     filter(url => url != null),
+     switchMap(url =>
+       this._http.get(url, {responseType: 'blob'}).pipe(
+         tap(blob => saveIconBlob(url, blob)),
+         catchError(_ => from(getIconBlobFromCache(url))),
+         map(blob => (blob != null ? this._toObjectUrl(blob) : url)), // fallback finale: url diretto, comportamento odierno
+       ),
+     ),
+   );
+
+   private _toObjectUrl(blob: Blob): string {
+     if (this._lastObjectUrl) {
+       URL.revokeObjectURL(this._lastObjectUrl);
+     }
+     this._lastObjectUrl = URL.createObjectURL(blob);
+     return this._lastObjectUrl;
+   }
+
+   ngOnDestroy(): void {
+     if (this._lastObjectUrl) {
+       URL.revokeObjectURL(this._lastObjectUrl);
+     }
+   }
+   ```
+
+3. Nel setter `@Input('wmMapButtonControl') set control(...)`, dopo aver assegnato `this._control`, se `value.type === 'button' && value.icon_url != null` chiamare `this._iconUrlEVT$.next(value.icon_url)`.
+
+4. Aggiornare il template: sostituire `[src]="iconUrl"` con `[src]="iconSrc$|async"`, mantenendo invariato `*ngIf="control.icon_url as iconUrl;else sanitazeIcon"` (il ramo `else` con l'SVG inline sanitizzato non cambia).
+
+**Nota di design:** `iconSrc$` emette in ordine: blob dal fetch riuscito (via object URL) → blob dalla cache se il fetch fallisce (via object URL) → url diretto come ultima risorsa se anche la cache è vuota. Il fallback finale mantiene il comportamento attuale (nessuna regressione se sia rete che cache falliscono).
+
+**Verifica step:** lettura del diff — confermare che il ramo `else sanitazeIcon` (icona SVG inline) non è toccato, e che `_toObjectUrl` revoca sempre l'object URL precedente prima di crearne uno nuovo.
+
+---
+
+## Step 3 — Unit test Karma
+
+File nuovo: `map-core/src/directives/hit-map.directive.spec.ts`
+
+Seguire il pattern di `pois.directive.spec.ts` (TestBed con `WmMapComponent` reale, `TestComponent` host con `wmMapHitMapCollection` + binding `[wmMapHitMapUrl]`, attesa di `isInit$` prima delle assertion). Mockare `HttpClient` fornito dal `TestBed` (`{provide: HttpClient, useValue: {get: jasmine.createSpy(...)}}`) e spiare `saveHitMapBoundaries`/`getHitMapBoundariesFromCache` importate dal modulo `localForage.ts` (`spyOn` sul modulo o dependency injection se il progetto lo consente — verificare pattern già usato altrove nel repo per spiare funzioni esportate da modulo, non da classe).
+
+Casi da coprire (ognuno un `it`):
+1. **Fetch riuscito con payload valido** → `_hitMapLayer` viene creato, `_addTileLayer()` chiamato, `saveHitMapBoundaries` chiamata con url e geojson.
+2. **Fetch fallito + cache presente** → `getHitMapBoundariesFromCache` chiamata, `_hitMapLayer` costruito dal payload di cache, `_addTileLayer()` chiamato (stesso comportamento del caso 1, sorgente dati diversa).
+3. **Fetch fallito + cache assente (`null`)** → nessun layer creato, nessuna eccezione lanciata, nessuna chiamata a `_buildGeojson`/`_addTileLayer`.
+4. **Fetch riuscito con payload non valido** (es. `{notAFeatureCollection: true}`) → `saveHitMapBoundaries` non scrive (verificabile spiando `hitMapBoundariesLocalForage.setItem` o il comportamento di `isValidFeatureCollection` se esportata) — la cache precedente non viene sovrascritta.
+5. **Cache con payload corrotto che fa lanciare `GeoJSON.readFeatures`** → l'eccezione non si propaga fuori dalla subscribe (il test non deve fallire per unhandled exception), nessun layer creato.
+
+⚠️ Nota da riportare in `notes.md`: questo spec, come gli altri directive spec del repo, crea una vera `OlMap` e **non gira in CI headless** (limite documentato in `map-core/CLAUDE.md` — solo i 27 test "utils" girano in CI). Va eseguito localmente con `nvm use 22 && npx ng test map-core` prima di aprire la PR.
+
+**Verifica step:** `nvm use 22 && npx ng test map-core` — tutti gli `it` di `hit-map.directive.spec.ts` passano in locale.
+
+---
+
+## Step 3B — Unit test Karma per `button.controls.map.ts` (estensione scope)
+
+File nuovo: `map-core/src/components/controls/button/button.controls.map.spec.ts`
+
+Setup minimo (componente presentazionale, non richiede `WmMapComponent`/`OlMap` reale — TestBed diretto su `WmMapButtonControls` con `HttpClientTestingModule` o `{provide: HttpClient, useValue: ...}`).
+
+Casi da coprire:
+1. **Fetch riuscito** → `iconSrc$` emette un object URL (`blob:...`), `saveIconBlob` chiamata con l'url e il blob.
+2. **Fetch fallito + cache presente** → `getIconBlobFromCache` chiamata, `iconSrc$` emette un object URL costruito dal blob di cache.
+3. **Fetch fallito + cache assente** → `iconSrc$` emette l'URL diretto originale (fallback finale, nessuna regressione).
+4. **`ngOnDestroy`** → `URL.revokeObjectURL` chiamata sull'ultimo object URL creato (spy su `URL.revokeObjectURL`/`URL.createObjectURL`).
+
+Questo spec **non** crea una `OlMap` (componente presentazionale puro) — verificare se rientra già nei test "utils" eseguibili in CI headless o se va aggiunto esplicitamente all'`include` di `configurations.ci` in `angular.json` (map-core), dato che non ha la stessa limitazione GPU degli altri directive/component spec.
+
+**Verifica step:** `nvm use 22 && npx ng test map-core` — tutti gli `it` di `button.controls.map.spec.ts` passano; verificare anche se girano in `CI=true npx ng test map-core --configuration=ci`.
+
+---
+
+## Step 4 — Notes e follow-up
+
+Compilare `docs/features/8219-fogli-carg-offline-dopo-riapertura-app/notes.md` (map-core) con:
+- Follow-up: proporre ticket Task separato per la rimozione di `loadHitmap$`/`loadHitmapFeatures`/`wmMapHitmapFeatures` (wm-core, codice apparentemente morto, individuato durante l'analisi di questo bug ma out of scope).
+- Nota sul limite dei test Karma su directive (non in CI, richiede esecuzione locale pre-PR).
+- Eventuali deviazioni emerse durante l'implementazione (es. se il try/catch va spostato dentro la callback `precompose` invece che attorno, come segnalato nello Step 2).
+- Nota sull'estensione di scope in corsa: bug delle icone dei controlli mappa scoperto durante la verifica manuale della fix principale, incluso su richiesta esplicita invece di aprire un ticket separato.
+
+---
+
+## Riepilogo file toccati
+
+| File | Repo | Modifica |
+|---|---|---|
+| `src/utils/localForage.ts` | map-core | Nuova istanza `hitMapBoundariesLocalForage` + `saveHitMapBoundaries`/`getHitMapBoundariesFromCache`/`isValidFeatureCollection`; nuova istanza `iconBlobsLocalForage` + `saveIconBlob`/`getIconBlobFromCache` |
+| `src/directives/hit-map.directive.ts` | map-core | Fallback da cache nel setter `wmMapHitMapUrl`, estrazione `_renderHitMap()` con try/catch |
+| `src/directives/hit-map.directive.spec.ts` (nuovo) | map-core | Unit test Karma per i 5 casi del layer di hit-test |
+| `src/components/controls/button/button.controls.map.ts` | map-core | Risoluzione `icon_url` come blob con cache locale e fallback, revoke object URL |
+| `src/components/controls/button/button.controls.map.spec.ts` (nuovo) | map-core | Unit test Karma per i 4 casi delle icone |
+| `docs/features/8219-.../notes.md` (nuovo) | map-core | Follow-up e deviazioni |

--- a/src/components/controls/button/button.controls.map.spec.ts
+++ b/src/components/controls/button/button.controls.map.spec.ts
@@ -1,0 +1,94 @@
+import {TestBed} from '@angular/core/testing';
+import {HttpClient} from '@angular/common/http';
+import {Store} from '@ngrx/store';
+import {of, throwError} from 'rxjs';
+import {take} from 'rxjs/operators';
+
+import {WmMapButtonControls} from './button.controls.map';
+import {ICONTROLSBUTTON} from '../../../types/model';
+import {iconBlobsLocalForage} from '../../../utils';
+
+const ICON_URL = 'https://example.com/icons/geologia-punti.png';
+
+const mockControl: ICONTROLSBUTTON = {
+  type: 'button',
+  id: 1,
+  label: {it: 'Geologia punti'},
+  icon: '',
+  icon_url: ICON_URL,
+  url: 'data',
+} as unknown as ICONTROLSBUTTON;
+
+describe('WmMapButtonControls', () => {
+  let component: WmMapButtonControls;
+  let httpGetSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [WmMapButtonControls],
+      providers: [
+        {provide: Store, useValue: {dispatch: () => {}}},
+        {provide: HttpClient, useValue: {get: () => of(null)}},
+      ],
+    });
+    const fixture = TestBed.createComponent(WmMapButtonControls);
+    component = fixture.componentInstance;
+    httpGetSpy = spyOn(TestBed.inject(HttpClient), 'get');
+  });
+
+  afterEach(() => {
+    component.ngOnDestroy();
+  });
+
+  it('fetch riuscito: iconSrc$ emette un object URL e salva il blob in cache', done => {
+    const blob = new Blob(['icon'], {type: 'image/png'});
+    const saveSpy = spyOn(iconBlobsLocalForage, 'setItem').and.resolveTo(blob);
+    spyOn(URL, 'createObjectURL').and.returnValue('blob:mock-1');
+    httpGetSpy.and.returnValue(of(blob));
+
+    component.iconSrc$.pipe(take(1)).subscribe(src => {
+      expect(src).toBe('blob:mock-1');
+      expect(saveSpy).toHaveBeenCalledWith(ICON_URL, blob);
+      done();
+    });
+    component.control = mockControl;
+  });
+
+  it('fetch fallito + cache presente: iconSrc$ emette un object URL dal blob di cache', done => {
+    const cachedBlob = new Blob(['cached'], {type: 'image/png'});
+    spyOn(iconBlobsLocalForage, 'getItem').and.resolveTo(cachedBlob);
+    spyOn(URL, 'createObjectURL').and.returnValue('blob:mock-cache');
+    httpGetSpy.and.returnValue(throwError(() => new Error('offline')));
+
+    component.iconSrc$.pipe(take(1)).subscribe(src => {
+      expect(src).toBe('blob:mock-cache');
+      done();
+    });
+    component.control = mockControl;
+  });
+
+  it('fetch fallito + cache assente: iconSrc$ emette l\'URL diretto (fallback invariato)', done => {
+    spyOn(iconBlobsLocalForage, 'getItem').and.resolveTo(null);
+    httpGetSpy.and.returnValue(throwError(() => new Error('offline')));
+
+    component.iconSrc$.pipe(take(1)).subscribe(src => {
+      expect(src).toBe(ICON_URL);
+      done();
+    });
+    component.control = mockControl;
+  });
+
+  it('ngOnDestroy: revoca l\'ultimo object URL creato', done => {
+    const blob = new Blob(['icon'], {type: 'image/png'});
+    const revokeSpy = spyOn(URL, 'revokeObjectURL');
+    spyOn(URL, 'createObjectURL').and.returnValue('blob:mock-destroy');
+    httpGetSpy.and.returnValue(of(blob));
+
+    component.iconSrc$.pipe(take(1)).subscribe(() => {
+      component.ngOnDestroy();
+      expect(revokeSpy).toHaveBeenCalledWith('blob:mock-destroy');
+      done();
+    });
+    component.control = mockControl;
+  });
+});

--- a/src/components/controls/button/button.controls.map.ts
+++ b/src/components/controls/button/button.controls.map.ts
@@ -4,14 +4,18 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnDestroy,
   Output,
   ViewEncapsulation,
 } from '@angular/core';
+import {HttpClient} from '@angular/common/http';
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 import {ICONTROLSBUTTON, ICONTROLSTITLE} from '../../../types/model';
-import {BehaviorSubject} from 'rxjs';
+import {BehaviorSubject, Observable} from 'rxjs';
+import {distinctUntilChanged, filter, map, switchMap} from 'rxjs/operators';
 import {Store} from '@ngrx/store';
 import {resetTogglePartition, setTogglePartition} from '../../../store/map-core.actions';
+import {getIconBlobFromCache, isValidIconBlob, saveIconBlob, withCacheFallback} from '@map-core/utils';
 
 @Component({
   standalone: false,
@@ -21,7 +25,7 @@ import {resetTogglePartition, setTogglePartition} from '../../../store/map-core.
         <ion-label class="wm-map-button-control-title">{{translationCallback(control.label)}}</ion-label>
     </ng-container>
     <div  class="wm-map-button-control-button" *ngIf="control.type === 'button'" (click)="click(control.id)">
-      <img  class="wm-map-button-control-icon"  [src]="iconUrl" *ngIf="control.icon_url as iconUrl;else sanitazeIcon" [ngClass]="[wmMapButtonControlSelected$.value?'selected':'']">
+      <img  class="wm-map-button-control-icon"  [src]="iconSrc$|async" *ngIf="control.icon_url as iconUrl;else sanitazeIcon" [ngClass]="[wmMapButtonControlSelected$.value?'selected':'']">
       <ng-template #sanitazeIcon>
         <div  class="wm-map-button-control-icon" [innerHtml]="sanitaze(control.icon)" [ngClass]="[wmMapButtonControlSelected$.value?'selected':'']"></div>
       </ng-template>
@@ -43,8 +47,12 @@ import {resetTogglePartition, setTogglePartition} from '../../../store/map-core.
   encapsulation: ViewEncapsulation.None,
   styleUrls: ['button.controls.map.scss'],
 })
-export class WmMapButtonControls {
+export class WmMapButtonControls implements OnDestroy {
   private _control: ICONTROLSTITLE | ICONTROLSBUTTON;
+  private _iconUrl$ = new BehaviorSubject<string | null>(null);
+  private _lastObjectUrl: string | null = null;
+
+  iconSrc$: Observable<string>;
 
   @Input('wmMapButtonControl') set control(value: ICONTROLSTITLE | ICONTROLSBUTTON) {
     if (value.type === 'button' && value.partitionProperties != null) {
@@ -55,6 +63,9 @@ export class WmMapButtonControls {
       this._control = {...value, partitionProperties};
     } else {
       this._control = value;
+    }
+    if (value.type === 'button' && value.icon_url != null) {
+      this._iconUrl$.next(value.icon_url);
     }
   }
 
@@ -81,7 +92,38 @@ export class WmMapButtonControls {
     public sanitizer: DomSanitizer,
     private _cdr: ChangeDetectorRef,
     private _store: Store,
-  ) {}
+    private _http: HttpClient,
+  ) {
+    this.iconSrc$ = this._iconUrl$.pipe(
+      filter(url => url != null),
+      distinctUntilChanged(),
+      switchMap(url =>
+        this._http.get(url, {responseType: 'blob'}).pipe(
+          withCacheFallback(
+            blob => saveIconBlob(url, blob),
+            () => getIconBlobFromCache(url),
+            'control icon',
+            isValidIconBlob,
+          ),
+          map(blob => (blob != null ? this._toObjectUrl(blob) : url)),
+        ),
+      ),
+    );
+  }
+
+  ngOnDestroy(): void {
+    if (this._lastObjectUrl) {
+      URL.revokeObjectURL(this._lastObjectUrl);
+    }
+  }
+
+  private _toObjectUrl(blob: Blob): string {
+    if (this._lastObjectUrl) {
+      URL.revokeObjectURL(this._lastObjectUrl);
+    }
+    this._lastObjectUrl = URL.createObjectURL(blob);
+    return this._lastObjectUrl;
+  }
 
   click(id): void {
     this._store.dispatch(resetTogglePartition());

--- a/src/directives/hit-map.directive.spec.ts
+++ b/src/directives/hit-map.directive.spec.ts
@@ -1,0 +1,171 @@
+// @ts-nocheck — mock GeoJSON payloads vs strict WmFeatureCollection typing, same convention as pois.directive.spec.ts
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {CommonModule} from '@angular/common';
+import {By} from '@angular/platform-browser';
+import {HttpClient} from '@angular/common/http';
+import {ActivatedRoute} from '@angular/router';
+import {Store} from '@ngrx/store';
+import {of, throwError} from 'rxjs';
+
+import {WmMapComponent, WmMapControls} from '../components';
+import {mockMapConf} from 'src/const.spec';
+import {WmMapHitMapDirective} from './hit-map.directive';
+import {hitMapBoundariesLocalForage} from '@map-core/utils';
+
+const HIT_MAP_URL = 'https://carg.example/confini.geojson';
+
+const validGeojson = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {carg_code: '1-A', id: 1},
+      geometry: {type: 'MultiPolygon', coordinates: []},
+    },
+  ],
+};
+
+@Component({
+  standalone: false,
+  template: `<wm-map wmMapHitMapCollection [wmMapHitMapUrl]="hitMapUrl" [wmMapConf]="conf"></wm-map>`,
+})
+class TestComponent {
+  conf = mockMapConf;
+  hitMapUrl = HIT_MAP_URL;
+}
+
+describe('WmMapHitMapDirective', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let directive: WmMapHitMapDirective;
+  let httpGetSpy: jasmine.Spy;
+
+  async function setup(): Promise<void> {
+    TestBed.configureTestingModule({
+      declarations: [WmMapHitMapDirective, TestComponent, WmMapComponent, WmMapControls],
+      imports: [CommonModule],
+      providers: [
+        {provide: HttpClient, useValue: {get: () => of(null)}},
+        {provide: Store, useValue: {dispatch: () => {}, select: () => of(null)}},
+        {provide: ActivatedRoute, useValue: {snapshot: {}, paramMap: of(null), queryParamMap: of(null)}},
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    const directiveEl = fixture.debugElement.query(By.directive(WmMapHitMapDirective));
+    directive = directiveEl.injector.get(WmMapHitMapDirective);
+    const http = directiveEl.injector.get(HttpClient);
+    httpGetSpy = spyOn(http, 'get');
+
+    await directive.mapCmp.isInit$;
+  }
+
+  it('fetch riuscito con payload valido: costruisce il layer e salva in cache', async () => {
+    await setup();
+    const saveSpy = spyOn(hitMapBoundariesLocalForage, 'setItem').and.resolveTo(validGeojson);
+    const buildSpy = spyOn<any>(directive, '_buildGeojson');
+    const tileSpy = spyOn<any>(directive, '_addTileLayer');
+    httpGetSpy.and.returnValue(of(validGeojson));
+
+    fixture.detectChanges();
+    directive.wmMapHitMapUrl = HIT_MAP_URL;
+    await Promise.resolve();
+    directive.mapCmp.map.dispatchEvent('precompose' as any);
+
+    expect(saveSpy).toHaveBeenCalledWith(HIT_MAP_URL, validGeojson);
+    expect(buildSpy).toHaveBeenCalledWith(validGeojson);
+    expect(tileSpy).toHaveBeenCalled();
+  });
+
+  it('fetch fallito con cache presente: costruisce il layer dalla cache', async () => {
+    await setup();
+    spyOn(hitMapBoundariesLocalForage, 'getItem').and.resolveTo(validGeojson as any);
+    const buildSpy = spyOn<any>(directive, '_buildGeojson');
+    const tileSpy = spyOn<any>(directive, '_addTileLayer');
+    httpGetSpy.and.returnValue(throwError(() => new Error('offline')));
+
+    fixture.detectChanges();
+    directive.wmMapHitMapUrl = HIT_MAP_URL;
+    await Promise.resolve();
+    await Promise.resolve();
+    directive.mapCmp.map.dispatchEvent('precompose' as any);
+
+    expect(buildSpy).toHaveBeenCalledWith(validGeojson);
+    expect(tileSpy).toHaveBeenCalled();
+  });
+
+  it('fetch fallito e cache assente: nessun layer, nessuna eccezione', async () => {
+    await setup();
+    spyOn(hitMapBoundariesLocalForage, 'getItem').and.resolveTo(null);
+    const buildSpy = spyOn<any>(directive, '_buildGeojson');
+    const tileSpy = spyOn<any>(directive, '_addTileLayer');
+    httpGetSpy.and.returnValue(throwError(() => new Error('offline')));
+
+    expect(() => {
+      fixture.detectChanges();
+      directive.wmMapHitMapUrl = HIT_MAP_URL;
+    }).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(tileSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetch riuscito con payload non valido: non sovrascrive la cache e fa fallback', async () => {
+    await setup();
+    const setItemSpy = spyOn(hitMapBoundariesLocalForage, 'setItem');
+    spyOn(hitMapBoundariesLocalForage, 'getItem').and.resolveTo(validGeojson as any);
+    const buildSpy = spyOn<any>(directive, '_buildGeojson');
+    const tileSpy = spyOn<any>(directive, '_addTileLayer');
+    httpGetSpy.and.returnValue(of({notAFeatureCollection: true}));
+
+    fixture.detectChanges();
+    directive.wmMapHitMapUrl = HIT_MAP_URL;
+    await Promise.resolve();
+    await Promise.resolve();
+    directive.mapCmp.map.dispatchEvent('precompose' as any);
+
+    expect(setItemSpy).not.toHaveBeenCalled();
+    expect(buildSpy).toHaveBeenCalledWith(validGeojson);
+    expect(tileSpy).toHaveBeenCalled();
+  });
+
+  it('cache con payload corrotto: la costruzione del layer non propaga eccezioni e non crea il tile layer', async () => {
+    await setup();
+    spyOn(hitMapBoundariesLocalForage, 'getItem').and.resolveTo(validGeojson as any);
+    spyOn<any>(directive, '_buildGeojson').and.throwError('malformed geojson');
+    const tileSpy = spyOn<any>(directive, '_addTileLayer');
+    httpGetSpy.and.returnValue(throwError(() => new Error('offline')));
+
+    fixture.detectChanges();
+    expect(() => {
+      directive.wmMapHitMapUrl = HIT_MAP_URL;
+    }).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(() => directive.mapCmp.map.dispatchEvent('precompose' as any)).not.toThrow();
+    expect(tileSpy).not.toHaveBeenCalled();
+  });
+
+  it('componente distrutto durante il cache-lookup pendente: nessuna eccezione', async () => {
+    await setup();
+    let resolveCache: (value: any) => void;
+    spyOn(hitMapBoundariesLocalForage, 'getItem').and.returnValue(
+      new Promise(resolve => (resolveCache = resolve)),
+    );
+    httpGetSpy.and.returnValue(throwError(() => new Error('offline')));
+
+    fixture.detectChanges();
+    directive.wmMapHitMapUrl = HIT_MAP_URL;
+    await Promise.resolve();
+
+    fixture.destroy();
+    expect(directive.mapCmp.map).toBeNull();
+
+    expect(() => resolveCache(validGeojson)).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});

--- a/src/directives/hit-map.directive.ts
+++ b/src/directives/hit-map.directive.ts
@@ -15,7 +15,15 @@ import {WmMapBaseDirective} from './base.directive';
 import {FEATURE_COLLECTION_ZINDEX} from '../readonly';
 import {Store} from '@ngrx/store';
 import {setHitMapFeatureCollections, setHitMapGeometry} from '../store/map-core.actions';
-import {coordsFromLonLat, CustomTileSource, extentToLonLat} from '@map-core/utils';
+import {
+  coordsFromLonLat,
+  CustomTileSource,
+  extentToLonLat,
+  getHitMapBoundariesFromCache,
+  isValidFeatureCollection,
+  saveHitMapBoundaries,
+  withCacheFallback,
+} from '@map-core/utils';
 @Directive({
   standalone: false,
   selector: '[wmMapHitMapCollection]',
@@ -29,16 +37,21 @@ export class WmMapHitMapDirective extends WmMapBaseDirective {
     this.mapCmp.isInit$
       .pipe(
         filter(e => e === true && url != null),
-        switchMap(_ => {
-          return this._http.get(url);
-        }),
+        switchMap(_ =>
+          this._http.get<WmFeatureCollection>(url).pipe(
+            withCacheFallback(
+              geojson => saveHitMapBoundaries(url, geojson),
+              () => getHitMapBoundariesFromCache(url),
+              'hit map boundaries',
+              isValidFeatureCollection,
+            ),
+          ),
+        ),
+        filter(geojson => geojson != null),
         take(1),
       )
       .subscribe((geojson: WmFeatureCollection) => {
-        this.mapCmp.map.once('precompose', () => {
-          this._buildGeojson(geojson);
-          this._addTileLayer(); // Aggiunta del nuovo tile sopra il layer esistente
-        });
+        this._renderHitMap(geojson);
       });
   }
 
@@ -93,6 +106,21 @@ export class WmMapHitMapDirective extends WmMapBaseDirective {
     } else {
       this._resetFeaturesStyle();
     }
+  }
+
+  private _renderHitMap(geojson: WmFeatureCollection): void {
+    if (this.mapCmp.map == null) {
+      // Componente distrutto (navigazione via) mentre il fetch/cache-lookup era ancora pendente.
+      return;
+    }
+    this.mapCmp.map.once('precompose', () => {
+      try {
+        this._buildGeojson(geojson);
+        this._addTileLayer(); // Aggiunta del nuovo tile sopra il layer esistente
+      } catch (e) {
+        console.error('Failed to render hit map from geojson', e);
+      }
+    });
   }
 
   private _addTileLayer(): void {

--- a/src/utils/cacheFallback.ts
+++ b/src/utils/cacheFallback.ts
@@ -1,0 +1,32 @@
+import {Observable, from, of} from 'rxjs';
+import {catchError, switchMap} from 'rxjs/operators';
+
+/**
+ * Shared shape for "fetch remote resource, persist it locally on success,
+ * fall back to the local cache on failure or on an invalid payload" —
+ * used by hit-map.directive.ts (GeoJSON boundaries) and
+ * button.controls.map.ts (control icons) so the two don't hand-roll
+ * the same switchMap/catchError chain with diverging validation.
+ */
+export function withCacheFallback<T>(
+  save: (value: T) => void,
+  getCached: () => Promise<T | null>,
+  logLabel: string,
+  isValid: (value: T) => boolean = () => true,
+) {
+  return (source: Observable<T>): Observable<T | null> =>
+    source.pipe(
+      switchMap(value => {
+        if (!isValid(value)) {
+          console.error(`${logLabel}: invalid payload received, falling back to cache`, value);
+          return from(getCached());
+        }
+        save(value);
+        return of(value);
+      }),
+      catchError(error => {
+        console.error(`${logLabel}: request failed, falling back to cache`, error);
+        return from(getCached());
+      }),
+    );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './performance';
 export * from './logger';
 export * from './localForage';
 export * from './geometry';
+export * from './cacheFallback';

--- a/src/utils/localForage.ts
+++ b/src/utils/localForage.ts
@@ -315,6 +315,71 @@ export async function removeFeatureCollection(url: string): Promise<void> {
   }
 }
 
+export function isValidFeatureCollection(payload: any): payload is WmFeatureCollection {
+  return payload != null && payload.type === 'FeatureCollection' && Array.isArray(payload.features);
+}
+
+/**
+ * Saves the CARG sheet boundaries GeoJSON for offline fallback, on a dedicated
+ * localForage instance separate from the per-sheet download cache
+ * (featureCollectionLocalForage). Refuses to overwrite a previously valid cache
+ * with a malformed payload (e.g. a 200 response carrying an HTML maintenance page).
+ */
+export async function saveHitMapBoundaries(
+  url: string,
+  geojson: WmFeatureCollection,
+): Promise<void> {
+  if (!isValidFeatureCollection(geojson)) {
+    console.error('Failed to save hit map boundaries: invalid GeoJSON payload', geojson);
+    return;
+  }
+  try {
+    await hitMapBoundariesLocalForage.setItem(url, geojson);
+  } catch (error) {
+    console.error('Failed to save hit map boundaries:', error);
+  }
+}
+
+export async function getHitMapBoundariesFromCache(
+  url: string,
+): Promise<WmFeatureCollection | null> {
+  try {
+    return await hitMapBoundariesLocalForage.getItem<WmFeatureCollection>(url);
+  } catch (error) {
+    console.error('Failed to get hit map boundaries from cache:', error);
+    return null;
+  }
+}
+
+/**
+ * Saves a map control icon blob for offline fallback, on a dedicated
+ * localForage instance separate from tiles/feature-collections/hit map boundaries.
+ */
+export function isValidIconBlob(blob: Blob): boolean {
+  return blob != null && blob.size > 0;
+}
+
+export async function saveIconBlob(url: string, blob: Blob): Promise<void> {
+  if (!isValidIconBlob(blob)) {
+    console.error('Failed to save icon blob: empty or invalid blob', blob);
+    return;
+  }
+  try {
+    await iconBlobsLocalForage.setItem(url, blob);
+  } catch (error) {
+    console.error('Failed to save icon blob:', error);
+  }
+}
+
+export async function getIconBlobFromCache(url: string): Promise<Blob | null> {
+  try {
+    return await iconBlobsLocalForage.getItem<Blob>(url);
+  } catch (error) {
+    console.error('Failed to get icon blob from cache:', error);
+    return null;
+  }
+}
+
 export async function saveHitmapFeature(
   id: string,
   hitMapFeature: WmFeature<MultiPolygon>,
@@ -418,6 +483,8 @@ export async function clearMapCoreData(): Promise<void> {
     featureCollectionHandlerLocalForage.clear(),
     hitMapFeaturesLocalForage.clear(),
     boundingBoxLocalForage.clear(),
+    hitMapBoundariesLocalForage.clear(),
+    iconBlobsLocalForage.clear(),
   ]);
 }
 
@@ -454,4 +521,14 @@ export const hitMapFeaturesLocalForage = localforage.createInstance({
 export const boundingBoxLocalForage = localforage.createInstance({
   name: 'map-core',
   storeName: 'boundingBox',
+});
+
+export const hitMapBoundariesLocalForage = localforage.createInstance({
+  name: 'map-core',
+  storeName: 'hitmapBoundaries',
+});
+
+export const iconBlobsLocalForage = localforage.createInstance({
+  name: 'map-core',
+  storeName: 'iconBlobs',
 });


### PR DESCRIPTION
## Summary
- Il layer di hit-test dei fogli CARG (`hit-map.directive.ts`) e le icone dei controlli mappa (`button.controls.map.ts`) dipendevano da un fetch remoto one-shot senza fallback: se l'app veniva riaperta offline dopo un download, il click sulla mappa non produceva alcun effetto.
- Aggiunta cache locale dedicata (nuove istanze `localForage`) con validazione del payload prima della scrittura, un operatore RxJS condiviso (`withCacheFallback`) per il pattern fetch→valida→salva→fallback, `distinctUntilChanged` sulle icone per evitare re-fetch ad ogni riconnessione di rete, e una guardia contro il crash quando il componente mappa viene distrutto mentre un cache-lookup è ancora pendente.
- Fix scoperto ed esteso durante l'implementazione (icone dei controlli mappa) su richiesta esplicita, oltre lo scope iniziale del ticket (solo fogli CARG).

Dettagli completi in `docs/features/8219-fogli-carg-offline-dopo-riapertura-app/{overview,plan,notes}.md`.

## Test plan
- [x] `CI=true npx ng test map-core --configuration=ci` → 31/31 SUCCESS (incluso il nuovo `button.controls.map.spec.ts`)
- [ ] `nvm use 22 && npx ng test map-core` in locale per verificare `hit-map.directive.spec.ts` (richiede browser con GPU, non eseguibile in modo affidabile nel sandbox di sviluppo usato per questa PR)
- [ ] Test manuale su device/emulatore Android in modalità aereo: scarica un foglio CARG online, chiudi/riapri l'app offline, verifica che il click sul foglio funzioni

Ticket: oc:8219

🤖 Generated with [Claude Code](https://claude.com/claude-code)